### PR TITLE
fixed the user/pwd in the docs for the vagrant setup

### DIFF
--- a/developer-guide/vagrant.md
+++ b/developer-guide/vagrant.md
@@ -40,7 +40,7 @@ $ vagrant up
 
 ### Info
 - Server IP: **192.168.33.6**
-- Directus user: **admin@admin.com** pass: **admin**
+- Directus user: **admin@getdirectus.com** pass: **password**
 - Database name: **directus**
 - MySQL user: **root**, pass: **123**
 


### PR DESCRIPTION
Was wondering why I couldn't login into the vagrant directus instance.

Looked into the `bootstrap.sh` file in the vagrant repository to find out the user and the password wasn't the same as indicated in the docs :)