### PR TITLE
Making something clearer...

### DIFF
--- a/advanced/api/configuration.md
+++ b/advanced/api/configuration.md
@@ -16,6 +16,10 @@ Subsequent projects can be added with new config files, using this naming conven
 
 ## Configure Manually
 
+::: note
+After configuring, if you would like to login to your custom project using the Directus Frontend, you'll need to add your new project as an entry into the `config.js` file.
+:::
+
 ### Create Config File
 
 Create a copy of [`config/api_sample.php`](https://github.com/directus/api/blob/master/config/api_sample.php) and change the name to `config/api.php` (for default project).


### PR DESCRIPTION
Question: *I've created a new project `api.myproject.php`, why doesn't it show in the web-interface login page?*

Answer: The big thing to remember is that the API and APP are decoupled. — If you head into the file `/public/admin/config.js`, you can configure which API's can be logged into through your APP. If you duplicate the current line `"../_/": "Directus Demo API"` and change it to (`"../myproject/": "My New Project"`), you should then see your new project as part of a dropdown in the APP.