### PR TITLE
Updated required php extensions

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -11,7 +11,7 @@ Directus is developed and tested on the LAMP stack, and therefore this is the on
     * A Database (empty or existing)
     * A Database User (with access to database)
 * **PHP 7.1+**
-    * Extensions:  `pdo`, `mysql`, `curl`, `gd`, `fileinfo`, and `mbstring`
+    * Extensions:  `pdo`, `mysql`, `curl`, `gd`, `fileinfo`, `libapache2-mod-php` and `mbstring`
 
 ::: tip Detailed Requirements
 View our [detailed requirements page](/advanced/requirements.md) to learn more about these requirements, neccesary permissions, and other server-specific prerequisites.


### PR DESCRIPTION
PHP extension `libapache2-mod-php` was missing in the docs, this should prevent the app from not finding the API