### PR TITLE
Fix for https://github.com/directus/api/issues/1364

### DIFF
--- a/extensions/hooks.md
+++ b/extensions/hooks.md
@@ -111,9 +111,9 @@ Filter Hooks are similar to Actions but alter the data that passes through it. F
 
 Name                                 | Description
 ------------------------------------ | ------------
-`item.create`                        | Item is created. You can also limit to a specific collection using `item.create.[collection-name]`. Supports `:before` (default)
-`item.read`                          | Item is read. You can also limit to a specific collection using `item.read.[collection-name]`. Supports `:before` (default)
-`item.update`                        | Item is updated. You can also limit to a specific collection using `item.update.[collection-name]`. Supports `:before` (default)
+`item.create:before`                 | Item is created. You can also limit to a specific collection using `item.create.[collection-name]:before`. Supports `:before` (has to be set explicitly)
+`item.read`                          | Item is read. You can also limit to a specific collection using `item.read.[collection-name]`. Supports `:after` (default)
+`item.update:before`                 | Item is updated. You can also limit to a specific collection using `item.update.[collection-name]:before`. Supports `:before` (has to be set explicitly)
 `response`                           | Before adding the content into the HTTP response body.  You can also limit to a specific collection using `response.[collection-name]`.
 `response.[method]`                  | Same as `response` but only executes for a specific http method, such as `GET, POST, DELETE, PATCH, PUT, OPTIONS`. You can also limit to a specific collection using `response.[method].[collection-name]`.
 


### PR DESCRIPTION
Fixes https://github.com/directus/api/issues/1364 (as https://github.com/directus/docs/pull/218 does not)
The fix in pull-request 218 seems wrong to me as :after and :before has to be set explicitly for create- and update- filters.