### PR TITLE
Update S3 Storage options to match API changes

### DIFF
--- a/docker/environment.md
+++ b/docker/environment.md
@@ -72,7 +72,7 @@
 | Variable                               | Type   | Default Value    |
 | -------------------------------------- | ------ | ---------------- |
 | DIRECTUS_STORAGE_OPTIONS_ACL           | string | "public-read"    |
-| DIRECTUS_STORAGE_OPTIONS_CACHE-CONTROL | string | "max-age=604800" |
+| DIRECTUS_STORAGE_OPTIONS_CACHECONTROL  | string | "max-age=604800" |
 
 ### Mail
 

--- a/extensions/storage-adapters.md
+++ b/extensions/storage-adapters.md
@@ -34,7 +34,7 @@ Then simply set the following into your configuration file (by default `config/a
     'region' => 'us-east-1',
     'options' => [
       'ACL' => 'public-read',
-      'Cache-Control' => 'max-age=604800'
+      'CacheControl' => 'max-age=604800'
     ],
     'endpoint' => 's3-endpoint',
     'root' => '/',


### PR DESCRIPTION
See https://github.com/directus/api/pull/1807

Note: the change in docker/environment.md is based on the guess on how the env names are generated. I couldn't find the code that confirms if this the correct casing