### PR TITLE
Clarify setup needed for authentication header

### DIFF
--- a/api/authentication.md
+++ b/api/authentication.md
@@ -42,6 +42,16 @@ Tokens can be passed in one of three ways:
 Authorization: bearer <token>
 ```
 
+By default, apache servers strip the Authentication header from requests, and blocks directus from seeing it. Adding the option 'CGIPassAuth On' to the directory statement in the site configuration in apache will resolve this.
+```
+<Directory /var/www/directus/public/>
+    Options Indexes FollowSymLinks
+    AllowOverride All
+    Require all granted
+    CGIPassAuth On
+</Directory>
+```
+
 ### Query Parameter
 
 ```


### PR DESCRIPTION
The standard installation following this documentation does not support using the authentication header option for authenticating API calls, due to apache stripping the header from call. Since it is listed as the first option, many people will probably experience this error. I think an explanation here makes sense - since the configuration is only needed if you want to use the authorization header.