### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -57,6 +57,10 @@ module.exports = {
     ["meta", { name: "msapplication-config", content: "/browserconfig.xml" }]
   ],
   themeConfig: {
+     algolia: {
+      apiKey: '9de6fda4b7ffe4f1c8f3ee3fae3d2612',
+      indexName: 'directus'
+    },
     lastUpdated: "Last Updated",
     repo: "directus/docs",
     docsDir: "",


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.