### PR TITLE
fix documentation example

### DIFF
--- a/api/relations.md
+++ b/api/relations.md
@@ -288,7 +288,7 @@ Returns the [relation object](#the-relation-object) for the relation that was ju
     "collection_many": "articles",
     "field_many": "author",
     "collection_one": "authors",
-    "field_one": null,
+    "field_one": "books",
     "junction_field": null
   }
 }


### PR DESCRIPTION
I believe there's a mistake in the api reference documentation example. "Create a relation" https://docs.directus.io/api/relations.html#create-a-relation response has field_one set to null while I was expecting it to be "books" from what was passed on the request.