### PR TITLE
required fields in example.

### DIFF
--- a/api/users.md
+++ b/api/users.md
@@ -486,6 +486,8 @@ Returns the [user object](#the-user-object) for the user that was just created.
 
 ```json
 {
+  "first_name": "Ben",
+  "last_name": "Haynes",
   "email": "demo@example.com",
   "password": "d1r3ctu5",
   "role": 3,
@@ -503,8 +505,8 @@ Returns the [user object](#the-user-object) for the user that was just created.
     "id": 14,
     "status": "active",
     "role": 3,
-    "first_name": null,
-    "last_name": null,
+    "first_name": "Ben",
+    "last_name": "Haynes",
     "email": "demo@example.com",
     "token": null,
     "last_access_on": null,


### PR DESCRIPTION
In the documentation https://docs.directus.io/api/users.html#create-a-user, the fields 'first_name' and 'last_name' are required, but in the example they are not sent. I believe it doesn't make sense to keep the example that way.