### PR TITLE
Fix optional attribute at update role

### DIFF
--- a/api/roles.md
+++ b/api/roles.md
@@ -340,7 +340,7 @@ Update an existing role
 
 <def-list>
 
-#### name <def-type alert>required</def-type>
+#### name <def-type>optional</def-type>
 Name of the role.
 
 #### description <def-type>optional</def-type>


### PR DESCRIPTION
I think the name attribute is not necessary to update a role because it's not in the example, also because it's an update. So I removed the 'required' description at name attribute.

https://docs.directus.io/api/roles.html#update-a-role