### PR TITLE
Update top page warning

### DIFF
--- a/api/query/page.md
+++ b/api/query/page.md
@@ -4,7 +4,7 @@ Using `page` along with `limit` can set the maximum number of items that will be
 
 ::: warning
 To see metadata, you need to precise the `meta` query param.
-Exemple : `?limit=10&page=3meta=*`
+Exemple : `?limit=10&page=3&meta=*`
 :::
 
 ## Examples


### PR DESCRIPTION
The page warning at the top is incorrect. 

The current one is `?limit=10&page=3meta=*` which won't give the desired result because an ampersand is missing. Kindly change to `?limit=10&page=3&meta=*`