### PR TITLE
(docs) update docker installation guide

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -90,3 +90,7 @@ Make sure to substitue `email@example.com` and `d1r3ctu5` with your preferred em
 ::: warning HTTPS
 You are required to run Directus using HTTPS.
 :::
+
+## Step 5: Log in
+
+Navigate to `http://localhost:8080/admin/#/login` and log in with the credentials in the previous step.


### PR DESCRIPTION
It is unclear where to navigate  after finishing the installation guide; add step to navigate to sign in page. 