### PR TITLE
Fixed the issue where the help fab cover partof the right page naviga…

### DIFF
--- a/.vuepress/theme/components/Page.vue
+++ b/.vuepress/theme/components/Page.vue
@@ -25,6 +25,6 @@ export default {
 @require '../styles/wrapper.styl'
 
 .page
-  padding-bottom 2rem
+  padding-bottom 3.5rem
   display block
 </style>


### PR DESCRIPTION

### Description
- Fixed the issue where the support fab covers the page navigation when they overlap on smaller screens.

### How
- I added more padding at the bottom of the page.
```diff
-  padding-bottom 2rem
+ padding-bottom 3.5rem
```
- Closes #31 
### Notes
- For the link `directus.io/solution` with the 404 error page. There is no way to navigate to this link on the website.