### PR TITLE
Use new spelling of DB_POOL config

### DIFF
--- a/self-hosted/config-options.md
+++ b/self-hosted/config-options.md
@@ -244,7 +244,7 @@ into unexpected behaviors.
 | `DB_PASSWORD`          | Database user's password. **Required** when using `pg`, `mysql`, `oracledb`, or `mssql`.                                                           | --                            |
 | `DB_FILENAME`          | Where to read/write the SQLite database. **Required** when using `sqlite3`.                                                                        | --                            |
 | `DB_CONNECTION_STRING` | When using `pg`, you can submit a connection string instead of individual properties. Using this will ignore any of the other connection settings. | --                            |
-| `DB_POOL_*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --                            |
+| `DB_POOL__*`            | Pooling settings. Passed on to [the `tarn.js`](https://github.com/vincit/tarn.js#usage) library.                                                   | --                            |
 | `DB_EXCLUDE_TABLES`    | CSV of tables you want Directus to ignore completely                                                                                               | `spatial_ref_sys,sysdiagrams` |
 | `DB_CHARSET`           | Charset/collation to use in the connection to MySQL/MariaDB                                                                                        | `UTF8_GENERAL_CI`             |
 | `DB_VERSION`           | Database version, in case you use the PostgreSQL adapter to connect a non-standard database. Not normally required.                                | --                            |
@@ -259,7 +259,7 @@ database instance.
 
 ::: tip Pooling
 
-All the `DB_POOL_` prefixed options are passed to [`tarn.js`](https://github.com/vincit/tarn.js#usage) through
+All the `DB_POOL__` prefixed options are passed to [`tarn.js`](https://github.com/vincit/tarn.js#usage) through
 [Knex](http://knexjs.org/#Installation-pooling)
 
 :::


### PR DESCRIPTION
See: https://github.com/directus/directus/commit/1c508c8bc5d51b50bdbec4e181645c8ccb4af2c6#commitcomment-78626937

Perhaps there should also be breaking change notice on the release page of v9.14.1 as this broke prod for us ;)
No idea how to propose that after the fact though.