### PR TITLE
Updated endpoint for trigger

### DIFF
--- a/reference/system/operations.md
+++ b/reference/system/operations.md
@@ -544,7 +544,7 @@ Result of the operation, if any.
 ### REST API
 
 ```
-POST /operations/trigger/:operation_uuid
+POST /flows/trigger/:operation_uuid
 ```
 
 ##### Example


### PR DESCRIPTION
Should the `POST` `trigger` endpoint be moved to `flows` as that's where it's run from?