### PR TITLE
Fix Typo In GitHub Docs Example

### DIFF
--- a/self-hosted/sso-examples.md
+++ b/self-hosted/sso-examples.md
@@ -95,8 +95,8 @@ AUTH_KEYCLOAK_IDENTIFIER_KEY="email"
 
 ```
 AUTH_GITHUB_DRIVER="oauth2"
-AUTH_GOOGLE_CLIENT_ID="..."
-AUTH_GOOGLE_CLIENT_SECRET="..."
+AUTH_GITHUB_CLIENT_ID="..."
+AUTH_GITHUB_CLIENT_SECRET="..."
 AUTH_GITHUB_AUTHORIZE_URL="https://github.com/login/oauth/authorize"
 AUTH_GITHUB_ACCESS_URL="https://github.com/login/oauth/access_token"
 AUTH_GITHUB_PROFILE_URL="https://api.github.com/user"


### PR DESCRIPTION
The example previously used `AUTH_GOOGLE` prefix for the
client id and secret.