### PR TITLE
enum value instead of string

### DIFF
--- a/reference/authentication.md
+++ b/reference/authentication.md
@@ -158,7 +158,7 @@ POST /graphql/system
 
 ```graphql
 mutation {
-	auth_refresh(refresh_token: "abc...def", mode: "json") {
+	auth_refresh(refresh_token: "abc...def", mode: json) {
 		access_token
 		refresh_token
 	}


### PR DESCRIPTION
"message": "Enum \"auth_mode\" cannot represent non-enum value: \"json\". Did you mean the enum value \"json\"?"