### PR TITLE
Enum instead of String

### DIFF
--- a/reference/system/server.md
+++ b/reference/system/server.md
@@ -110,7 +110,7 @@ type Query {
 
 ```graphql
 query {
-	server_specs_graphql(scope: "system")
+	server_specs_graphql(scope: system)
 }
 ```
 


### PR DESCRIPTION
"message": "Enum \"graphql_sdl_scope\" cannot represent non-enum value: \"system\". Did you mean the enum value \"system\"?"