### PR TITLE
Adding SendGrid to self-hosted/config-options

### DIFF
--- a/self-hosted/config-options.md
+++ b/self-hosted/config-options.md
@@ -803,11 +803,11 @@ AUTH_FACEBOOK_ICON="facebook"
 
 ## Email
 
-| Variable             | Description                                                              | Default Value          |
-| -------------------- | ------------------------------------------------------------------------ | ---------------------- |
-| `EMAIL_VERIFY_SETUP` | Check if email setup is properly configured.                             | `true`                 |
-| `EMAIL_FROM`         | Email address from which emails are sent.                                | `no-reply@directus.io` |
-| `EMAIL_TRANSPORT`    | What to use to send emails. One of `sendmail`, `smtp`, `mailgun`, `ses`. | `sendmail`             |
+| Variable             | Description                                                                          | Default Value          |
+| -------------------- | ------------------------------------------------------------------------------------ | ---------------------- |
+| `EMAIL_VERIFY_SETUP` | Check if email setup is properly configured.                                         | `true`                 |
+| `EMAIL_FROM`         | Email address from which emails are sent.                                            | `no-reply@directus.io` |
+| `EMAIL_TRANSPORT`    | What to use to send emails. One of `sendmail`, `smtp`, `mailgun`, `sendgrid`, `ses`. | `sendmail`             |
 
 Based on the `EMAIL_TRANSPORT` used, you must also provide the following configurations:
 
@@ -838,6 +838,12 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 | `EMAIL_MAILGUN_API_KEY` | Your Mailgun API key.                                                             | --                |
 | `EMAIL_MAILGUN_DOMAIN`  | A domain from [your Mailgun account](https://app.mailgun.com/app/sending/domains) | --                |
 | `EMAIL_MAILGUN_HOST`    | Allows you to specify a custom host.                                              | `api.mailgun.net` |
+
+### SendGrid (`sendgrid`)
+
+| Variable                 | Description            | Default Value     |
+| ------------------------ | ---------------------- | ----------------- |
+| `EMAIL_SENDGRID_API_KEY` | Your SendGrid API key. | --                |
 
 ### AWS SES (`ses`)
 


### PR DESCRIPTION
Docs for using SendGrid as email transport (feat implemented at [PR](https://github.com/directus/directus/pull/15384))