### PR TITLE
GraphQL metadata information

### DIFF
--- a/reference/query.md
+++ b/reference/query.md
@@ -586,4 +586,22 @@ Returns the item count of the collection you're querying, taking the current fil
 
 ### GraphQL
 
-n/a
+::: warning GraphQL
+
+GraphQL does not have meta fields like the REST API.
+As an alternative, you can retrieve the count using Aggregation.
+
+:::
+
+```
+query {
+	articles_aggregated {
+		count {
+			id
+		}
+	}
+}
+```
+
+For more details, see:
+- [Aggregation & Grouping](#aggregation-grouping)

--- a/reference/query.md
+++ b/reference/query.md
@@ -574,6 +574,15 @@ Returns the total item count of the collection you're querying.
 
 Returns the item count of the collection you're querying, taking the current filter/search parameters into account.
 
+::: warning GraphQL
+
+GraphQL does not have meta fields like the REST API.  
+As an alternative, you can retrieve the count using Aggregation.
+
+For more details, see: [Aggregation & Grouping](#aggregation-grouping)
+
+:::
+
 ### REST API
 
 ```
@@ -586,13 +595,6 @@ Returns the item count of the collection you're querying, taking the current fil
 
 ### GraphQL
 
-::: warning GraphQL
-
-GraphQL does not have meta fields like the REST API.
-As an alternative, you can retrieve the count using Aggregation.
-
-:::
-
 ```
 query {
 	articles_aggregated {
@@ -602,6 +604,3 @@ query {
 	}
 }
 ```
-
-For more details, see:
-- [Aggregation & Grouping](#aggregation-grouping)


### PR DESCRIPTION
Currently, there is no information about metadata using GraphQL.

When I was searching on how to retrieve metadata using GraphQL, it was not easy to find and cost me a lot of time.

In this PR, I've added a notice and example on how to fetch the count for a collection.

![image](https://user-images.githubusercontent.com/38376566/190508891-fa87f174-95c6-4bf9-a719-b33111545401.png)
