### PR TITLE
Add sidebar link for operations under extensions

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -536,6 +536,10 @@ function sidebar() {
 					text: 'Modules',
 				},
 				{
+					link: "/extensions/operations",
+					text: "Operations",
+				},
+				{
 					// type: 'page',
 					link: '/extensions/panels',
 					text: 'Panels',

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -536,8 +536,8 @@ function sidebar() {
 					text: 'Modules',
 				},
 				{
-					link: "/extensions/operations",
-					text: "Operations",
+					link: '/extensions/operations',
+					text: 'Operations',
 				},
 				{
 					// type: 'page',


### PR DESCRIPTION
It was originally added in #36 but for VuePress, so this PR re-adds it for the current VitePress.