### PR TITLE
add ServerSideEncryption env variable for s3

### DIFF
--- a/self-hosted/config-options.md
+++ b/self-hosted/config-options.md
@@ -550,14 +550,15 @@ Based on your configured driver, you must also provide the following configurati
 
 ### S3 (`s3`)
 
-| Variable                      | Description | Default Value      |
-| ----------------------------- | ----------- | ------------------ |
-| `STORAGE_<LOCATION>_KEY`      | User key    | --                 |
-| `STORAGE_<LOCATION>_SECRET`   | User secret | --                 |
-| `STORAGE_<LOCATION>_BUCKET`   | S3 Bucket   | --                 |
-| `STORAGE_<LOCATION>_REGION`   | S3 Region   | --                 |
-| `STORAGE_<LOCATION>_ENDPOINT` | S3 Endpoint | `s3.amazonaws.com` |
-| `STORAGE_<LOCATION>_ACL`      | S3 ACL      | --                 |
+| Variable                      							| Description 							| Default Value      |
+| ------------------------------------------- | -------------------------	| ------------------ |
+| `STORAGE_<LOCATION>_KEY`      							| User key    							| --                 |
+| `STORAGE_<LOCATION>_SECRET`   							| User secret 							| --                 |
+| `STORAGE_<LOCATION>_BUCKET`   							| S3 Bucket   							| --                 |
+| `STORAGE_<LOCATION>_REGION`   							| S3 Region   							| --                 |
+| `STORAGE_<LOCATION>_ENDPOINT` 							| S3 Endpoint 							| `s3.amazonaws.com` |
+| `STORAGE_<LOCATION>_ACL`      							| S3 ACL      							| --                 |
+| `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION`	| S3 Server Side Encryption	| --                 |
 
 ### Azure (`azure`)
 


### PR DESCRIPTION
Reference `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION` for server side encryption in AWS s3. 
Support doc for https://github.com/directus/directus/pull/15952