### PR TITLE
Update ASSETS_CACHE_TTL default to correct value

### DIFF
--- a/self-hosted/config-options.md
+++ b/self-hosted/config-options.md
@@ -618,7 +618,7 @@ purposes, collection of additional metadata must be configured:
 
 | Variable                               | Description                                                                                                                             | Default Value |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `ASSETS_CACHE_TTL`                     | How long assets will be cached for in the browser. Sets the `max-age` value of the `Cache-Control` header.                              | `30m`         |
+| `ASSETS_CACHE_TTL`                     | How long assets will be cached for in the browser. Sets the `max-age` value of the `Cache-Control` header.                              | `30d`         |
 | `ASSETS_TRANSFORM_MAX_CONCURRENT`      | How many file transformations can be done simultaneously                                                                                | `4`           |
 | `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` | The max pixel dimensions size (width/height) that is allowed to be transformed                                                          | `6000`        |
 | `ASSETS_TRANSFORM_MAX_OPERATIONS`      | The max number of transform operations that is allowed to be processed (excludes saved presets)                                         | `5`           |


### PR DESCRIPTION
Was stated as `30m` when it should say `30d`. See https://github.com/directus/directus/blob/4ab04f67f3a281e86de34150bae790bcd74d47c9/api/src/env.ts#L248