### PR TITLE
Fix spellcheck ci

### DIFF
--- a/configuration/flows/operations.md
+++ b/configuration/flows/operations.md
@@ -121,7 +121,7 @@ will cancel the original event transaction to the database.
 :::tip Node Modules
 
 For security reasons, module usage is disabled by default. You can configure what Node Modules are available through
-(the `FLOWS_EXEC_ALLOWED_MODULES` environment variable)[/self-hosted/config-options#security].
+[the `FLOWS_EXEC_ALLOWED_MODULES` environment variable](/self-hosted/config-options#security).
 
 :::
 

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -81,6 +81,7 @@ cardinality
 CDNs?
 CLI
 CloudFront
+Cloudinary's
 Cloudron
 CloudSQL
 CMS


### PR DESCRIPTION
- Add `Cloudinary's` to dictionary
- Fix reversed bracket syntax for link, which caused false positive by the spellcheck (it should be `[text](link)` instead of `(text)[link]`)