### PR TITLE
Sidebar-Menu: Add self-hosted installation guide

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -649,16 +649,26 @@ function sidebar() {
 			collapsed: true,
 			items: [
 				{
+					link: '/self-hosted/installation',
+					text: 'Installation (All)'
+					items: [
+						{
+							link: '/self-hosted/installation/cli',
+							text: 'CLI',
+						},
+						{
+							link: '/self-hosted/installation/docker',
+							text: 'Docker',
+						},
+					],
+				},
+				{
 					link: '/self-hosted/quickstart',
 					text: 'Quickstart',
 				},
 				{
 					link: '/self-hosted/config-options',
 					text: 'Config Options',
-				},
-				{
-					link: '/self-hosted/installation/docker',
-					text: 'Docker Guide',
 				},
 				{
 					link: '/self-hosted/sso',

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -650,7 +650,7 @@ function sidebar() {
 			items: [
 				{
 					link: '/self-hosted/installation',
-					text: 'Installation (All)'
+					text: 'Installation (All)',
 					items: [
 						{
 							link: '/self-hosted/installation/cli',


### PR DESCRIPTION
Currently there's only the Docker-Guide listed for manual installation. This PR adds a link to the whole installation list as well as the CLI and Docker to the menu.

**Discussion:**
I've added the CLI and Docker to the menu, as I assume these are the most used ones. On the other hand this could suggest there's no other guide. Therefore it could make sense to only link the main installation guide