### PR TITLE
Add port mapping to Docker quickstart instructions

### DIFF
--- a/self-hosted/quickstart.md
+++ b/self-hosted/quickstart.md
@@ -25,6 +25,8 @@ version: '3'
 services:
   directus:
     image: directus/directus:latest
+    ports:
+      - 8055:8055
     volumes:
       - ./uploads:/directus/uploads
       - ./database:/directus/database


### PR DESCRIPTION
Hi there 🙂 I was just trying to get Directus up and running using Docker on my local machine, and I had an issue using the instructions on the [quickstart page](https://docs.directus.io/self-hosted/quickstart.html).

Using the current instructions, port 8055 wasn't being mapped, so I couldn't access Directus after it started running. This is what was showing up in 'Inspect' in Docker Desktop:
<img width="491" alt="Port 8055 not bound" src="https://user-images.githubusercontent.com/10627494/212501460-a6de28c7-0842-4458-8ace-b45b02baa383.png">

Adding 'ports' to the 'directus' service seems to fix it. I've done that in the commit below.

As a novice Docker user, I found it a little confusing that the ['quickstart'](https://docs.directus.io/self-hosted/quickstart.html) instructions (using docker-compose) differ from the instructions in ['Docker Guide'](https://docs.directus.io/self-hosted/docker-guide.html) (which say to use `docker run`). But that's a separate issue.

Thanks 🙂