### PR TITLE
Update config-options.md

### DIFF
--- a/self-hosted/config-options.md
+++ b/self-hosted/config-options.md
@@ -925,7 +925,7 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide the following configu
 
 | Variable                | Description      | Default Value |
 | ----------------------- | ---------------- | ------------- |
-| `EMAIL_SMTP_NAME`       | SMTP Name        | --            |
+| `EMAIL_SMTP_NAME`       | SMTP Hostname    | --            |
 | `EMAIL_SMTP_HOST`       | SMTP Host        | --            |
 | `EMAIL_SMTP_PORT`       | SMTP Port        | --            |
 | `EMAIL_SMTP_USER`       | SMTP User        | --            |


### PR DESCRIPTION
Updated an important fact for configuring SMTP. EMAIL_SMTP_NAME is the hostname, and often needs to be the same as the EMAIL_SMTP_HOST