### PR TITLE
Updated Folder to Directory

### DIFF
--- a/content/11.configuration/10.extensions.md
+++ b/content/11.configuration/10.extensions.md
@@ -15,7 +15,7 @@ description: Configuration for extensions and the Directus Marketplace.
 | `EXTENSIONS_LOCATION`<sup>[4]</sup>    | What configured storage location to use for extensions.                         |                |
 | `EXTENSIONS_LIMIT`                     | Maximum number of extensions you allow to be installed through the Marketplace. |                |
 
-<sup>[1]</sup> If `EXTENSIONS_LOCATION` is configured, this is the path to the extensions folder within the selected
+<sup>[1]</sup> If `EXTENSIONS_LOCATION` is configured, this is the path to the extensions directory within the selected
 storage location.
 
 <sup>[2]</sup> `EXTENSIONS_AUTO_RELOAD` will not work when the `EXTENSION_LOCATION` environment variable is set.

--- a/content/11.configuration/13.migrations.md
+++ b/content/11.configuration/13.migrations.md
@@ -12,7 +12,7 @@ Directus allows adding custom migration files that run whenever the migration co
 
 The file name follows the following structure `[identifier]-[name].js`, for example `20201202A-my-custom-migration.js`.
 
-Every file in the root of the `migrations` directory is treated as a migration. Files that don't include a `-` character are ignored. If you want to rely on shared helper functions between migrations, put them in a subfolder so they aren't loaded in by the migrations helper.
+Every file in the root of the `migrations` directory is treated as a migration. Files that don't include a `-` character are ignored. If you want to rely on shared helper functions between migrations, put them in a subdirectory so they aren't loaded in by the migrations helper.
 
 ## Structure
 

--- a/content/13.releases/2.breaking-changes.md
+++ b/content/13.releases/2.breaking-changes.md
@@ -128,9 +128,9 @@ For security reasons, mutations of the following system collections via relation
 Legacy extension type directory-based structure (`/interfaces/my-interface/`, `/endpoints/my-endpoint`, etc) are being
 removed in favor of relying on the `package.json` file for metadata including extension type.
 
-If your extensions are already relying on the up-to-date extensions folder paradigm (extensions in the root of your
-extensions folder prefixed with `directus-extension-`) no action is required at this point. If you're currently relying
-on the legacy format for extensions, recognizable by each extension type having it's own folder, like `endpoints`,
+If your extensions are already relying on the up-to-date extensions directory paradigm (extensions in the root of your
+extensions directory prefixed with `directus-extension-`) no action is required at this point. If you're currently relying
+on the legacy format for extensions, recognizable by each extension type having it's own directory, like `endpoints`,
 `hooks`, etc, you will have to update your extensions before upgrading to this version.
 
 Directus will ignore extensions that use the legacy format starting in this version.
@@ -161,7 +161,7 @@ If your extension does not already have one, add a `directus:extension` object t
 Notes:
 
 - Make sure `type` matches the JS type of your `dist` file (cjs or esm).
-- Make sure `directus:extension.type` matches the type of extension. This should match the legacy type folder name.
+- Make sure `directus:extension.type` matches the type of extension. This should match the legacy type directory name.
 - Make sure `directus:extension.path`points to your extensions’ `dist` file.
 - Make sure `directus:extension.source` points to your extensions’ source code entry point or set to an empty string
   `""` when the source code is not stored alongside the `package.json` file.


### PR DESCRIPTION
A small PR to update the word 'folder' to 'directory' when talking about code/files on a filesystem. 'Folder' can continue to be used when talking about the Files module of Directus, any settings that explicitly refer to a folder, and, of course, when talking about the `directus_files` collection.