### PR TITLE
Style docs footer email input in dark mode

### DIFF
--- a/app/components/DocsFooter.vue
+++ b/app/components/DocsFooter.vue
@@ -83,6 +83,7 @@ onMounted(() => {
 		input[type=email] {
 			@apply w-full;
 			@apply rounded-md text-xs sm:text-sm;
+			@apply dark:bg-gray-900;
 			@apply placeholder-gray-400 dark:placeholder-gray-500;
 			@apply border border-gray-200 dark:border-gray-800 p-2;
 		}
@@ -92,9 +93,6 @@ onMounted(() => {
 		@apply bg-purple-500 text-white;
 		@apply border border-purple-200 dark:border-purple-800 py-2 px-4;
 		@apply flex-none;
-	}
-	.hs-error-msg {
-
 	}
 }
 </style>


### PR DESCRIPTION
Fix style of email input in dark mode. Before it was using the user agent default style.

|Before|After|
|-|-|
|![CleanShot 2024-12-22 at 19 09 49@2x](https://github.com/user-attachments/assets/8380b69a-1b24-4727-9415-f0e169865370)|![CleanShot 2024-12-22 at 19 10 23@2x](https://github.com/user-attachments/assets/783c65e6-bfeb-4a15-bb17-496519a648df)|
