### PR TITLE
Fix shiki wasm in vercel deployment

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,11 +22,19 @@ export default defineNuxtConfig({
 		baseURL: '/docs/',
 	},
 
+	css: [
+		'~/assets/css/algolia.css',
+	],
+
 	site: {
 		url: 'https://directus.io',
 		name: 'Directus Docs',
 		description: 'Explore our resources and powerful data engine to build your projects confidently.',
 		defaultLocale: 'en',
+	},
+
+	colorMode: {
+		dataValue: 'theme',
 	},
 
 	content: {
@@ -77,6 +85,10 @@ export default defineNuxtConfig({
 				depth: 1,
 			},
 		},
+	},
+
+	build: {
+		transpile: ['shiki'],
 	},
 
 	future: {
@@ -135,12 +147,4 @@ export default defineNuxtConfig({
 	robots: {
 		robotsTxt: false,
 	},
-
-	css: [
-		'~/assets/css/algolia.css'
-	],
-
-	colorMode: {
-		dataValue: 'theme'
-	}
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,10 +87,6 @@ export default defineNuxtConfig({
 		},
 	},
 
-	build: {
-		transpile: ['shiki'],
-	},
-
 	future: {
 		compatibilityVersion: 4,
 	},
@@ -114,6 +110,19 @@ export default defineNuxtConfig({
 			// ~ Rijk 12/19/2024
 			ignore: ['/docs/api/</span'],
 		},
+	},
+
+	vite: {
+		build: {
+			rollupOptions: {
+				external: [
+					'shiki/onig.wasm',
+				],
+			},
+		},
+		assetsInclude: [
+			'**/*.wasm',
+		],
 	},
 
 	algolia: {


### PR DESCRIPTION
There seems to be a config mismatch in shiki / nitro / nuxt building https://github.com/nuxt/nuxt/issues/28127 / https://github.com/nuxt/nuxt/issues/29116, which causes 500s on SSR rendering shiki. That in turn causes #97 on the prod deployment. This behaves a bit differently on my local dev mode, so we'll have to do some pipeline bashing to get this to work correctly 