### PR TITLE
Clarify `deep` query example

### DIFF
--- a/content/guides/4.connect/3.query-parameters.md
+++ b/content/guides/4.connect/3.query-parameters.md
@@ -446,13 +446,15 @@ const result = await directus.request(
 Only get 3 related posts, with only the top rated comment nested:
 ```json
 {
-	"related_posts": {
-		"_limit": 3,
-		"comments": {
-			"_sort": "rating",
-			"_limit": 1
+	"deep": {
+		"related_posts": {
+			"_limit": 3,
+			"comments": {
+				"_sort": "rating",
+				"_limit": 1
+			}
 		}
-	}
+  }
 }
 ```
 ::


### PR DESCRIPTION
Make the usage clearer by putting the query explicitly under “deep”.

Related to issue https://github.com/directus/docs/issues/144 and PR https://github.com/directus/directus/pull/24476