### PR TITLE
feat: add `::example` component

### DIFF
--- a/app/components/content/Example.vue
+++ b/app/components/content/Example.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+	title?: string
+	icon?: string
+}>(), {
+	title: 'Example',
+	icon: 'material-symbols:info-outline'
+});
+</script>
+
+<template>
+	<Callout :icon>
+		<strong>{{ title }}</strong>
+		<slot/>
+	</Callout>
+</template>

--- a/content/guides/4.connect/2.filter-rules.md
+++ b/content/guides/4.connect/2.filter-rules.md
@@ -62,8 +62,7 @@ The `operator` must be any valid filter operator such as 'equals' or 'contains'.
 
 The `value` can be any fixed static value or one of the provided dynamic variables.
 
-::callout{icon="material-symbols:info-outline"}
-**Example**  
+::example
 This filter checks the `title` field contains the case-sensitive substring 'Directus':
 ```json
 {
@@ -131,8 +130,7 @@ This behavior can be overridden by using the explicit `_some` and `_none` operat
 | `$NOW`               | The current timestamp                                                                            |
 | `$NOW(<adjustment>)` | The current timestamp plus/minus a given distance, for example `$NOW(-1 year)`, `$NOW(+2 hours)` |
 
-::callout{icon="material-symbols:info-outline"}
-**Examples**  
+::example{title="Examples"}
   ::tabs
     ::div{class="pr-6"}
     ---


### PR DESCRIPTION
Add `Example` component to simplify the example callouts. Takes care of setting the correct title and icon by default.

Instead of 

```md
::callout{icon="material-symbols:info-outline"}
**Example**  

Some example text
```

we can now write

```md
::example
Some example text
```

If the `icon` or `title` need to changed they can be passed in, so 

```md
::example{title="Examples"}
```