### PR TITLE
Remove additional ticks in `Using Authentication in Next.js`

### DIFF
--- a/content/tutorials/1.getting-started/using-authentication-in-next-js.md
+++ b/content/tutorials/1.getting-started/using-authentication-in-next-js.md
@@ -101,7 +101,6 @@ Install the Directus SDK by running the following:
 
 Initialize the Directus SDK:
 
-```
 Create a new file at `./lib/directus.ts` with the following contents:
 
 ```typescript


### PR DESCRIPTION
This removes additional ticks that were present for the `./lib/directus.ts` code block


### before
![Screenshot 2025-02-14 at 5 01 31 PM](https://github.com/user-attachments/assets/467984db-6e34-4eb8-8cfe-334b36191fcd)

### after
![Screenshot 2025-02-14 at 5 03 26 PM](https://github.com/user-attachments/assets/360d6bc8-42ec-4699-9b67-fd655fdae50d)

