### PR TITLE
Add `isDirectusError` type guard docs

### DIFF
--- a/content/guides/4.connect/5.sdk.md
+++ b/content/guides/4.connect/5.sdk.md
@@ -397,7 +397,7 @@ Polyfill libraries will often register itself to the `globalThis` object. For ex
 
 ### `isDirectusError` type guard
 
-The sdk exports an `isDirectusError` type guard utility function to determine if the error thrown was from the API
+The SDK exports an `isDirectusError` type guard utility function to determine if the error thrown was from the API
 
 ```js
 import { createDirectus, rest, isDirectusError, readItems } from '@directus/sdk';

--- a/content/guides/4.connect/5.sdk.md
+++ b/content/guides/4.connect/5.sdk.md
@@ -392,3 +392,26 @@ const directus = createDirectus('http://directus.example.com');
 ```
 
 Polyfill libraries will often register itself to the `globalThis` object. For example, the `react-native-url-polyfill` package.
+
+## Error Handling
+
+### `isDirectusError` type guard
+
+The sdk exports the `isDirectusError` type guard to make it easier to determine if the error thrown was due to an error returned from the API
+
+```js
+import { createDirectus, rest, isDirectusError, readItems } from '@directus/sdk';
+
+const directus = createDirectus('http://directus.example.com').with(rest());
+
+try {
+  const request = await directus.request(readItems('posts')));
+} catch(error){
+  if(isDirectusError(error)){
+    // some error has been returned from the API
+  } else {
+    // some unknown non API error has been thrown (e.g. unable to parse the JSON response)
+  }
+}
+```
+

--- a/content/guides/4.connect/5.sdk.md
+++ b/content/guides/4.connect/5.sdk.md
@@ -397,7 +397,7 @@ Polyfill libraries will often register itself to the `globalThis` object. For ex
 
 ### `isDirectusError` type guard
 
-The sdk exports the `isDirectusError` type guard to make it easier to determine if the error thrown was due to an error returned from the API
+The sdk exports an `isDirectusError` type guard utility function to determine if the error thrown was from the API
 
 ```js
 import { createDirectus, rest, isDirectusError, readItems } from '@directus/sdk';


### PR DESCRIPTION
This PR documents the new `isDirectusError` type guard utility function exported by the `sdk`


Related: https://github.com/directus/directus/pull/24764
Merged after: https://github.com/directus/directus/pull/24764