### PR TITLE
Fix warning callout for metrics configuration

### DIFF
--- a/content/configuration/16.metrics.md
+++ b/content/configuration/16.metrics.md
@@ -12,9 +12,8 @@ To enable performance and error measurement of connected services, Directus can 
 | `METRICS_TOKENS`   | A CSV of tokens to allow access to via a `Authorization: Metrics <token>` header. By default it is restricted to admins | --                             |
 | `METRICS_SERVICES` | A CSV of directus services to observe metrics for. Currently `database`, `cache`, `redis` and `storage` are supported   | `database,cache,redis,storage` |
 
-::: warning Metric Aggregation
-
+::callout{icon="material-symbols:warning-rounded" color="amber"}
+**Metric Aggregation**
 If Directus is running within a PM2 context, then metrics will be aggregated on a per scheduled job frequency. Ensure
 Prometheus' scrape frequency takes that into account.
-
-:::
+::


### PR DESCRIPTION
Replace legacy warning format with callout

### Before
![image](https://github.com/user-attachments/assets/cd7ebe00-6a3d-49fe-a7a7-d2fa75eaff91)

### After
![image](https://github.com/user-attachments/assets/c8f21149-649d-4115-9fbe-f11f850f7d28)
