### PR TITLE
Render HTTP status codes and their respective bodies

### DIFF
--- a/app/components/ApiEndpoint.vue
+++ b/app/components/ApiEndpoint.vue
@@ -120,8 +120,8 @@ const responseBodyExample = computed(() => {
 			</div>
 
 			<div
-        v-for="responseBodyObject, code, index in responseBodyObjects"
-        :key="code"
+				v-for="responseBodyObject, code, index in responseBodyObjects"
+				:key="code"
 				class="mb-12 last:mb-0"
 			>
 				<ProseH4 :id="slugify(operation.summary!) + '-' + responseBodyObject.code + '-response'">


### PR DESCRIPTION
Closes #210 

Before:
<img width="1182" alt="before image showing only 200 response" src="https://github.com/user-attachments/assets/76abdcf6-16e9-4d83-b1aa-7770a9823668" />

After:
<img width="1190" alt="after image showing all responses" src="https://github.com/user-attachments/assets/5decebd3-41d6-45c9-8a3c-b22e6b0233c2" />

