### PR TITLE
Add `items.create` action hook breaking change

### DIFF
--- a/content/releases/3.breaking-changes/2.version-11.md
+++ b/content/releases/3.breaking-changes/2.version-11.md
@@ -3,7 +3,7 @@ title: Version 11
 description: Breaking changes may require action on your part before upgrading.
 ---
 
-## Version 11.X.X
+## Version 11.6.0
 
 ### items.create action hook receives final payload
 

--- a/content/releases/3.breaking-changes/2.version-11.md
+++ b/content/releases/3.breaking-changes/2.version-11.md
@@ -7,7 +7,7 @@ description: Breaking changes may require action on your part before upgrading.
 
 ### items.create action hook receives final payload
 
-The final payload after filter hooks and preset changes are applied is now passed down to the action hook.
+We now pass the final payload to the `items.create` action hook, after the filter hooks and preset changes have been applied, instead of the original payload.
 
 ## Version 11.5.0
 

--- a/content/releases/3.breaking-changes/2.version-11.md
+++ b/content/releases/3.breaking-changes/2.version-11.md
@@ -3,6 +3,12 @@ title: Version 11
 description: Breaking changes may require action on your part before upgrading.
 ---
 
+## Version 11.X.X
+
+### items.create action hook receives final payload
+
+The final payload after filter hooks and preset changes are applied is now passed down to the action hook.
+
 ## Version 11.5.0
 
 ### Changed error message when a Flow condition operation fails


### PR DESCRIPTION
Added a section for the upcoming breaking changes to the `items.create` action hook that now pass in the altered payload instead of the original.

Related PR: https://github.com/directus/directus/pull/24812