### PR TITLE
Improve subscription `uid` wording

### DIFF
--- a/content/guides/7.realtime/2.subscriptions.md
+++ b/content/guides/7.realtime/2.subscriptions.md
@@ -76,8 +76,11 @@ should be returned. -->
 
 ## Using UIDs
 
-You can have multiple ongoing CRUD actions and subscriptions at a time. When doing so, it is highly recommended to
-add an additional `uid` property to your request, which will be included in related item change events.
+The `uid` property serves as a unique identifier included in the message payload. When multiple subscriptions are added to the same collection, the `uid` helps to distinguish the responses of these subscriptions watching different filters or events. A unique identifier will be generated on the server if not explicitly provided when subscribing.
+
+::callout{icon="material-symbols:warning-rounded" color="amber"}
+If a duplicate `uid` is sent, it will overwrite the previously set subscription for that `uid` on the connection.
+::
 
 ```json
 {
@@ -99,8 +102,6 @@ When you receive responses, the same `uid` will be included as a property:
 	"uid": "any-string-value"
 }
 ```
-
-Use a new `uid` for every subscription, and you can easily tell which subscription an event is related to.
 
 ## Unsubscribing from Changes
 

--- a/content/guides/7.realtime/2.subscriptions.md
+++ b/content/guides/7.realtime/2.subscriptions.md
@@ -79,7 +79,7 @@ should be returned. -->
 The `uid` property serves as a unique identifier included in the message payload. When multiple subscriptions are added to the same collection, the `uid` helps to distinguish the responses of these subscriptions watching different filters or events. A unique identifier will be generated on the server if not explicitly provided when subscribing.
 
 ::callout{icon="material-symbols:warning-rounded" color="amber"}
-If a duplicate `uid` is sent, it will overwrite the previously set subscription for that `uid` on the connection.
+When manually setting the `uid` property its value needs to be unique per WebSocket connection. Any subsequent duplicate `uid` subscriptions will be ignored.
 ::
 
 ```json


### PR DESCRIPTION
This PR improves the explanation on how the `uid` property in a realtime subscription operates.

Fixes: #275