### PR TITLE
Update using-authentication-in-nuxt.md

### DIFF
--- a/content/tutorials/1.getting-started/using-authentication-in-nuxt.md
+++ b/content/tutorials/1.getting-started/using-authentication-in-nuxt.md
@@ -139,7 +139,11 @@ Depending on your project configuration and if you are in development or product
 
   ```ts
   routeRules: {
-	"/directus/**": { proxy: import.meta.env.API_URL },
+    "/directus/**": {     
+      proxy: {
+        to: import.meta.env.API_URL + "/**"
+      } 
+    },
 },
   ```
 


### PR DESCRIPTION
This is the proper proxy setting to forward the full route to the API. Otherwise the calls to `/directus/any` are always forwarded to the `/` of the API