### PR TITLE
Add `PUBLIC_URL` note for `Chunked Uploads`

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -117,7 +117,7 @@ Large files can be uploaded in chunks to improve reliability and efficiency, esp
 
 ::callout{icon="material-symbols:info-outline"}
 
-This feature requires the `PUBLIC_URL` to be set correctly
+This feature requires the `PUBLIC_URL` to be set correctly to [where your API is publicly accessible](https://directus.io/docs/configuration/general).
 
 ::
 

--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -115,6 +115,12 @@ Large files can be uploaded in chunks to improve reliability and efficiency, esp
 | `TUS_UPLOAD_EXPIRATION` | The expiry duration for uncompleted files with no upload activity. | `10m`         |
 | `TUS_CLEANUP_SCHEDULE`  | Cron schedule to clean up the expired uncompleted uploads.         | `0 * * * *`   |
 
+::callout{icon="material-symbols:info-outline"}
+
+This feature requires the `PUBLIC_URL` to be set correctly
+
+::
+
 ::callout{icon="material-symbols:warning-rounded" color="amber"}
 
 **Chunked Upload Restrictions**<br/>


### PR DESCRIPTION
Added a note regarding `PUBLIC_URL` to be set for chunked uploads to work as expected.

Aims to prevent common issues users may encounter when enabling TUS (see issues https://github.com/directus/directus/issues/25093 and https://github.com/directus/directus/issues/24056).