### PR TITLE
docs: Set correct image for Map Layout

### DIFF
--- a/content/guides/2.content/3.layouts.md
+++ b/content/guides/2.content/3.layouts.md
@@ -147,7 +147,7 @@ but ideally two datetime Fields (to set a start time and end time).
 
 ## Map Layout
 
-![Calendar layout](/img/a967c260-3597-49c5-92d1-0f044ced44c5.webp)
+![Calendar layout](/img/e0835568-a39e-452e-bec2-27bcc114bdd6.webp)
 
 This layout is ideal for collections that emphasize geospatial data. It provides a world map, with items displayed as
 points, lines, and other geometry.


### PR DESCRIPTION
In the docs, the Map Layout has the same image as the Calendar Layout, see: https://directus.io/docs/guides/content/layouts#map-layout

This PR sets the correct screenshot for the Map Layout.

New image:
![](https://directus.io/docs/img/e0835568-a39e-452e-bec2-27bcc114bdd6.webp)