### PR TITLE
Fix markdown syntax

### DIFF
--- a/content/tutorials/4.migration/promoting-changes-between-environments-in-directus.md
+++ b/content/tutorials/4.migration/promoting-changes-between-environments-in-directus.md
@@ -234,4 +234,4 @@ You should have two Directus projects - this guide will refer to them as the "ba
     applying the diffs without this safeguard. In case the schema has been changed in the meantime, the diff must be
     regenerated.
     ::
-  ::
+::


### PR DESCRIPTION
https://directus.io/docs/tutorials/migration/promoting-changes-between-environments-in-directus

Because of bad indenting at the end of the file, the last tabs-component is displayed with an extra tab:

![image](https://github.com/user-attachments/assets/a23158fe-7644-4205-93e4-476c1089bfca)

After code change:

![image](https://github.com/user-attachments/assets/e32e3e77-b396-4307-ae00-de4dc07c862c)
