### PR TITLE
fix: replace readItem with readItems to match usage

### DIFF
--- a/content/tutorials/1.getting-started/fetch-data-from-directus-with-nextjs.md
+++ b/content/tutorials/1.getting-started/fetch-data-from-directus-with-nextjs.md
@@ -140,7 +140,7 @@ single file can be used for all of the top-level pages.
 ```jsx
 import directus from '@/lib/directus';
 import { notFound } from 'next/navigation';
-import { readItem } from '@directus/sdk';
+import { readItems } from '@directus/sdk';
 
 async function getPage(slug) {
 	try {


### PR DESCRIPTION
The code was importing `readItem` from @directus/sdk but calling `readItems`, which caused a not found error. Replaced the import with `readItems` to ensure the method used is actually imported.
It fixes my error when coding.