### PR TITLE
Fix body schema for generate user TFA

### DIFF
--- a/public/oas.yaml
+++ b/public/oas.yaml
@@ -8702,7 +8702,7 @@ paths:
         content:
           application/json:
             schema:
-              type: string
+              type: object
               required:
                 - password
               properties:


### PR DESCRIPTION
Currently in the docs it is showing that body must be `[string]` but it should be
```json
{
  "password": "d1r3ctu5"
}