### PR TITLE
Fix Hubspot Tracking

### DIFF
--- a/app/plugins/hubspot.client.ts
+++ b/app/plugins/hubspot.client.ts
@@ -1,0 +1,16 @@
+declare global {
+	interface Window {
+		_hsq: [string, unknown?][];
+	}
+}
+
+export default defineNuxtPlugin(() => {
+	const router = useRouter();
+	router.afterEach((to, from) => {
+		if (to.path !== from.path) {
+			const _hsq = (window._hsq = window._hsq || []);
+			_hsq.push(['setPath', to.fullPath]);
+			_hsq.push(['trackPageView']);
+		}
+	});
+});


### PR DESCRIPTION
Hubspot Tracking doesn't automatically handle SPA's/Hybrid Sites Client Side routing so we need to manually add pages that navigate client side to their queue.