### PR TITLE
Add Google Tag Manager

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
 		'@nuxtjs/seo',
 		'@vueuse/nuxt',
 		'nuxt-posthog',
-		...(( process.env.ALGOLIA_APPLICATION_ID && process.env.ALGOLIA_API_KEY )
+		...((process.env.ALGOLIA_APPLICATION_ID && process.env.ALGOLIA_API_KEY)
 			? ['@nuxtjs/algolia']
 			: []),
 	],
@@ -85,6 +85,16 @@ export default defineNuxtConfig({
 		markdown: {
 			toc: {
 				depth: 1,
+			},
+		},
+	},
+
+	runtimeConfig: {
+		public: {
+			scripts: {
+				googleTagManager: {
+					id: process.env.GOOGLE_TAG_MANAGER_ID!,
+				},
 			},
 		},
 	},
@@ -165,5 +175,11 @@ export default defineNuxtConfig({
 
 	robots: {
 		robotsTxt: false,
+	},
+
+	scripts: {
+		registry: {
+			googleTagManager: true,
+		},
 	},
 });


### PR DESCRIPTION
We never added the Google Tag Manager to the documentation site. This adds it with the exact same implementation as the website!

TODO:

- [x] Update ENV in Vercel!