### PR TITLE
A11y docs for keyboard navigation and shortcuts

### DIFF
--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -1,6 +1,6 @@
 ---
 description: We are always looking for ways to make Directus Studio more accessible. Here are some of the methods we currently support.
-title: Accessibility (WIP)
+title: Accessibility
 ---
 
 We are in the process of making Directus Studio accessible. Since version Version 11.9.0 the app provides keyboard navigation.

--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -3,7 +3,6 @@ description: We are always looking for ways to make Directus Studio more accessi
 title: Accessibility
 ---
 
-We are in the process of making Directus Studio accessible. Since version Version 11.9.0 the app provides keyboard navigation.
 
 ## Keyboard Navigation
 

--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -1,5 +1,5 @@
 ---
-description: Work in progress
+description: We are always looking for ways to make Directus Studio more accessible. Here are some of the methods we currently support.
 title: Accessibility (WIP)
 ---
 

--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -1,0 +1,36 @@
+---
+description: Work in progress
+title: Accessibility (WIP)
+---
+
+We are in the process of making Directus Studio accessible. Since version Version 11.9.0 the app provides keyboard navigation.
+
+## Keyboard Navigation
+
+You can navigate through Directus Studio entirely with your keyboard. The Skip Menu makes it easy to jump between page sections.
+
+### Shortcuts
+
+- Navigation is primarily done with the `Tab` key and occasionally with the arrow keys.
+- Enter your selection with the `enter` or `space` keys.
+- Save with `meta` + `s`.
+- Apply edits in modals/drawers/popovers with `meta` + `enter`.
+- Cancel/exit modals/drawers/popovers with the `escape` key.
+
+Special shortcuts for the TinyMCE/WYSIWYG Editor:
+
+- `alt` + `F10` Focus/jump to toolbar
+- Arrow Keys: Navigate left/right through toolbar
+- `Esc`: Return to the editor content area
+
+Read more: https://www.tiny.cloud/docs/tinymce/6/tinymce-and-screenreaders/
+
+### Things to keep in mind
+
+- Visual Editor is only accessible on the Directus side — not your website. So we always need to click an edit button first, then the
+  overlays are accessible.
+- Manual Sorting is currently not supported/accessible.
+- The DateTime interface is currently not supported/accessible.
+- Once focused, the code interface (Codemirror) cannot be exited using the tab key.
+- The Markdown interface also doesn’t allow you to exit the field. This is because it supports tabs inside the editor’s
+  text content.


### PR DESCRIPTION
## Scope

What's changed:

- Added a new page under Getting Started

Related PR: https://github.com/directus/directus/pull/25214

## Review Notes / Questions

- I think this information should be included, but not emphasized too heavily. Is there a better place for this section than on its own page?
- Are there icons for shortcuts?