### PR TITLE
Document new `websocket.authenticate` hook

### DIFF
--- a/content/guides/09.extensions/2.api-extensions/1.hooks.md
+++ b/content/guides/09.extensions/2.api-extensions/1.hooks.md
@@ -83,8 +83,8 @@ The context object has the following properties:
 
 | Name                           | Payload                               | Meta                                        |
 | ------------------------------ | ------------------------------------- | ------------------------------------------- |
-| `websocket.authenticate`       | The message sent over the WebSocket.  | `message`                                   |
-| `websocket.message`            | The message sent over the WebSocket.  |                                             |
+| `websocket.authenticate`       | The default accountability object.    | `message`                                   |
+| `websocket.message`            | The message sent over the WebSocket.  | `client`                                    |
 | `request.not_found`            | `false`                               | `request`, `response`                       |
 | `request.error`                | The request errors.                   |                                             |
 | `database.error`               | The database error.                   | `client`                                    |
@@ -92,7 +92,7 @@ The context object has the following properties:
 | `auth.jwt`                     | The auth token.                       | `status`, `user`, `provider`, `type`        |
 | `auth.create`<sup>[1]</sup>    | The created user.                     | `identifier`, `provider`, `providerPayload` |
 | `auth.update`<sup>[2]</sup>    | The updated auth token<sup>[3]</sup>. | `identifier`, `provider`, `providerPayload` |
-| `authenticate`                 | The empty accountability object.      | `req`                                       |
+| `authenticate`                 | The default accountability object.    | `req`                                       |
 | `email.send`                   | The email payload.                    |                                             |
 | `(<collection>.)items.query`   | The items query.                      | `collection`                                |
 | `(<collection>.)items.read`    | The read item.                        | `query`, `collection`                       |

--- a/content/guides/09.extensions/2.api-extensions/1.hooks.md
+++ b/content/guides/09.extensions/2.api-extensions/1.hooks.md
@@ -83,6 +83,7 @@ The context object has the following properties:
 
 | Name                           | Payload                               | Meta                                        |
 | ------------------------------ | ------------------------------------- | ------------------------------------------- |
+| `websocket.authenticate`       | The message sent over the WebSocket.  | `message`                                   |
 | `websocket.message`            | The message sent over the WebSocket.  |                                             |
 | `request.not_found`            | `false`                               | `request`, `response`                       |
 | `request.error`                | The request errors.                   |                                             |


### PR DESCRIPTION
### What's Changed
- Document the new `websocket.authenticate` filter hook introduced in https://github.com/directus/directus/pull/25344
- Update wording for `authenticate` filter hook payload description
- Add missing `client` meta property in `websocket.message` filter hook