### PR TITLE
Add info about `half`, `fill`, & `full` width on fields

### DIFF
--- a/content/guides/01.data-model/2.fields.md
+++ b/content/guides/01.data-model/2.fields.md
@@ -101,6 +101,14 @@ Each field can be configured to be half or full width in the editor. Two half-wi
 
 Field width is not in the field configuration, but can be set by clicking on :icon{name="material-symbols:more-vert" title="Field Width Button"} in the collection data model page.
 
+::callout{icon="material-symbols:info-outline"}
+`half` fields will go from `[start]` until `[half]` in the grid system, but have a maximum width of `380px` defined by the `--form-column-max-width` css variable.
+
+`full` fields will be the sum of 2 `half` fields, with a maximum width of `760px`.
+
+`fill` fields will fill the available space, without any maximum.
+::
+
 ## System Collection Fields
 
 System collections have a number of default fields that cannot be configured as they are required for Directus to operate. However, additional fields can be added to any system collection.

--- a/content/guides/01.data-model/2.fields.md
+++ b/content/guides/01.data-model/2.fields.md
@@ -102,11 +102,14 @@ Each field can be configured to be half or full width in the editor. Two half-wi
 Field width is not in the field configuration, but can be set by clicking on :icon{name="material-symbols:more-vert" title="Field Width Button"} in the collection data model page.
 
 ::callout{icon="material-symbols:info-outline"}
-`half` fields will go from `[start]` until `[half]` in the grid system, but have a maximum width of `380px` defined by the `--form-column-max-width` css variable.
+**Field Width Configurations**
 
-`full` fields will be the sum of 2 `half` fields, with a maximum width of `760px`.
+- `half` fields will go from `[start]` until `[half]` in the grid system, but have a maximum width of `380px` defined by the `--form-column-max-width` css variable.
 
-`fill` fields will fill the available space, without any maximum.
+- `full` fields will be the sum of 2 `half` fields, with a maximum width of `760px`.
+
+- `fill` fields will fill the available space, without any maximum.
+
 ::
 
 ## System Collection Fields


### PR DESCRIPTION
This info was provided by @joselcvarela in a support ticket, but I think it would be helpful to have in the docs.