### PR TITLE
Update 2.create-a-project.md

### DIFF
--- a/content/getting-started/2.create-a-project.md
+++ b/content/getting-started/2.create-a-project.md
@@ -66,6 +66,9 @@ services:
 			- ./database:/directus/database
 			- ./uploads:/directus/uploads
 			- ./extensions:/directus/extensions
+		post_start:
+			- command: chown node:node /directus/database /directus/uploads /directus/extensions
+			  user: root
 		environment:
 			SECRET: "replace-with-random-value"
 			ADMIN_EMAIL: "admin@example.com"


### PR DESCRIPTION
The https://directus.io/docs/getting-started/create-a-project contains a `docker-compose.yml` which will cause a permissions error when trying to upload files via the admin panel just after first start. It happens because docker "bind mount" host directory (in contrast to named volumes) is not initialized with owner/permissions taken from inside the container directory. 

But since from Docker Compose 2.30 it became possible to use a post-start hook to fix this problem - https://docs.docker.com/compose/how-tos/lifecycle/#post-start-hooks.

So quick fix for `.yml` might be:
```
services:
    directus:
        # ...
        volumes:
            - ./database:/directus/database
            - ./uploads:/directus/uploads
            - ./extensions:/directus/extensions
        post_start:
            - command: chown node:node /directus/database /directus/uploads /directus/extensions
              user: root
        # ...
```
P.S.: this can also be fixed by adding `chown` to the `CMD` in the `Dockerfile` (like `postgres` docker image does)