### PR TITLE
Upgrade PostHog and Change to Match Website Module

### DIFF
--- a/modules/posthog/index.ts
+++ b/modules/posthog/index.ts
@@ -1,0 +1,110 @@
+import { defineNuxtModule, addImports, addComponent, addPlugin, createResolver, addTypeTemplate } from '@nuxt/kit';
+import type { PostHogConfig } from 'posthog-js';
+import { defu } from 'defu';
+
+export interface ModuleOptions {
+	/**
+	 * The PostHog API key
+	 * @default process.env.POSTHOG_API_KEY
+	 * @example 'phc_1234567890abcdef1234567890abcdef1234567890a'
+	 * @type string
+	 * @docs https://posthog.com/docs/api
+	 */
+	publicKey: string;
+
+	/**
+	 * The PostHog API host
+	 * @default process.env.POSTHOG_API_HOST
+	 * @example 'https://app.posthog.com'
+	 * @type string
+	 * @docs https://posthog.com/docs/api
+	 */
+	host: string;
+
+	/**
+	 * If set to true, the module will capture page views automatically
+	 * @default true
+	 * @type boolean
+	 * @docs https://posthog.com/docs/product-analytics/capture-events#single-page-apps-and-pageviews
+	 */
+	capturePageViews?: boolean;
+
+	/**
+	 * PostHog Client options
+	 * @default {
+	 *    api_host: process.env.POSTHOG_API_HOST,
+	 *    loaded: () => <enable debug mode if in development>
+	 * }
+	 * @type object
+	 * @docs https://posthog.com/docs/libraries/js#config
+	 */
+	clientOptions?: Partial<PostHogConfig>;
+
+	/**
+	 * If set to true, the module will be disabled (no events will be sent to PostHog).
+	 * This is useful for development environments. Directives and components will still be available for you to use.
+	 * @default false
+	 * @type boolean
+	 */
+	disabled?: boolean;
+}
+
+type PosthogRuntimeConfig = Required<ModuleOptions>;
+
+export default defineNuxtModule<ModuleOptions>({
+	meta: {
+		name: 'nuxt-posthog',
+		configKey: 'posthog',
+	},
+	defaults: {
+		publicKey: process.env.POSTHOG_API_KEY as string,
+		host: process.env.POSTHOG_API_HOST as string,
+		capturePageViews: true,
+		disabled: false,
+	},
+	setup(options, nuxt) {
+		const { resolve } = createResolver(import.meta.url);
+
+		// Public runtimeConfig
+		nuxt.options.runtimeConfig.public.posthog = defu<PosthogRuntimeConfig, PosthogRuntimeConfig[]>(
+			nuxt.options.runtimeConfig.public.posthog,
+			{
+				publicKey: options.publicKey,
+				host: options.host,
+				capturePageViews: options.capturePageViews ?? true,
+				clientOptions: options.clientOptions ?? {},
+				disabled: options.disabled ?? false,
+			},
+		);
+
+		// Make sure url and key are set
+		if (!nuxt.options.runtimeConfig.public.posthog.publicKey) {
+			// eslint-disable-next-line no-console
+			console.warn('Missing PostHog API public key, set it either in `nuxt.config.ts` or via env variable');
+		}
+
+		if (!nuxt.options.runtimeConfig.public.posthog.host) {
+			// eslint-disable-next-line no-console
+			console.warn('Missing PostHog API host, set it either in `nuxt.config.ts` or via env variable');
+		}
+
+		addPlugin(resolve('./runtime/plugins/directives'));
+		addPlugin(resolve('./runtime/plugins/posthog.client'));
+		addPlugin(resolve('./runtime/plugins/posthog.server'));
+
+		addImports({
+			from: resolve('./runtime/composables/usePostHogFeatureFlag'),
+			name: 'usePostHogFeatureFlag',
+		});
+
+		addComponent({
+			filePath: resolve('./runtime/components/PostHogFeatureFlag.vue'),
+			name: 'PostHogFeatureFlag',
+		});
+
+		addTypeTemplate({
+			filename: 'types/posthog-directives.d.ts',
+			src: resolve('./runtime/types/directives.d.ts'),
+		});
+	},
+});

--- a/modules/posthog/runtime/components/PostHogFeatureFlag.vue
+++ b/modules/posthog/runtime/components/PostHogFeatureFlag.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import usePostHogFeatureFlag from '../composables/usePostHogFeatureFlag';
+
+const { name } = withDefaults(
+	defineProps<{
+		name: string;
+		match?: boolean | string;
+	}>(),
+	{ match: true },
+);
+
+const { getFeatureFlag } = usePostHogFeatureFlag();
+
+const featureFlag = computed(() => getFeatureFlag(name));
+</script>
+
+<template>
+	<slot v-if="featureFlag?.value === match" :payload="featureFlag.payload" />
+</template>

--- a/modules/posthog/runtime/composables/usePostHogFeatureFlag.ts
+++ b/modules/posthog/runtime/composables/usePostHogFeatureFlag.ts
@@ -1,0 +1,23 @@
+import { useState } from '#app';
+import type { JsonType } from 'posthog-js';
+
+export default () => {
+	const posthogFeatureFlags = useState<Record<string, boolean | string> | undefined>('ph-feature-flags');
+	const posthogFeatureFlagPayloads = useState<Record<string, JsonType> | undefined>('ph-feature-flag-payloads');
+
+	const isFeatureEnabled = (feature: string) => {
+		return posthogFeatureFlags.value?.[feature] ?? false;
+	};
+
+	const getFeatureFlag = (feature: string) => {
+		return {
+			value: posthogFeatureFlags.value?.[feature] ?? false,
+			payload: posthogFeatureFlagPayloads.value?.[feature],
+		};
+	};
+
+	return {
+		isFeatureEnabled,
+		getFeatureFlag,
+	};
+};

--- a/modules/posthog/runtime/directives/v-capture.ts
+++ b/modules/posthog/runtime/directives/v-capture.ts
@@ -1,0 +1,88 @@
+import { useNuxtApp } from '#app';
+import type { ObjectDirective, FunctionDirective, DirectiveBinding } from 'vue';
+
+type CaptureEvent = {
+	name: string;
+	properties?: Record<string, any>;
+};
+
+type CaptureModifiers = {
+	click?: boolean;
+	hover?: boolean;
+};
+
+type EventHandler = {
+	event: string;
+	handler: (_event: Event) => void;
+};
+
+const listeners = new WeakMap<HTMLElement, EventHandler[]>();
+
+const directive: FunctionDirective<HTMLElement, CaptureEvent | string> = (
+	el,
+	binding: DirectiveBinding<CaptureEvent | string> & { modifiers: CaptureModifiers },
+) => {
+	const { value, modifiers } = binding;
+
+	// Don't bind if the value is undefined
+	if (!value) {
+		return;
+	}
+
+	const { $posthog } = useNuxtApp();
+
+	function capture(_event: Event) {
+		if (!$posthog) return;
+
+		if (typeof value === 'string') {
+			$posthog.capture(value);
+		} else {
+			$posthog.capture(value.name, value.properties);
+		}
+	}
+
+	// Determine the events to listen for based on the modifiers
+	const events: string[] = [];
+
+	if (Object.keys(modifiers).length === 0) {
+		// Default to click if no modifiers are specified
+		events.push('click');
+	} else {
+		if (modifiers.click) events.push('click');
+		if (modifiers.hover) events.push('mouseenter');
+	}
+
+	// Remove existing event listeners
+	if (listeners.has(el)) {
+		const oldEvents = listeners.get(el) as EventHandler[];
+
+		oldEvents.forEach(({ event, handler }) => {
+			el.removeEventListener(event, handler);
+		});
+	}
+
+	// Add new event listeners and store them
+	const eventHandlers = events.map((event) => {
+		const handler = capture.bind(null);
+		el.addEventListener(event, handler);
+		return { event, handler };
+	});
+
+	listeners.set(el, eventHandlers);
+};
+
+export const vCapture: ObjectDirective = {
+	mounted: directive,
+	updated: directive,
+	unmounted(el) {
+		if (listeners.has(el)) {
+			const eventHandlers = listeners.get(el) as EventHandler[];
+
+			eventHandlers.forEach(({ event, handler }) => {
+				el.removeEventListener(event, handler);
+			});
+
+			listeners.delete(el);
+		}
+	},
+};

--- a/modules/posthog/runtime/plugins/directives.ts
+++ b/modules/posthog/runtime/plugins/directives.ts
@@ -1,0 +1,6 @@
+import { vCapture } from '../directives/v-capture';
+import { defineNuxtPlugin } from '#app';
+
+export default defineNuxtPlugin(({ vueApp }) => {
+	vueApp.directive('capture', vCapture);
+});

--- a/modules/posthog/runtime/plugins/posthog.client.ts
+++ b/modules/posthog/runtime/plugins/posthog.client.ts
@@ -1,0 +1,77 @@
+import { defineNuxtPlugin, useCookie, useRouter, useRuntimeConfig, useState } from '#app';
+import { posthog, type PostHog, type JsonType, type PostHogConfig } from 'posthog-js';
+import { defu } from 'defu';
+
+export default defineNuxtPlugin({
+	name: 'posthog',
+	enforce: 'pre',
+	setup: async () => {
+		const config = useRuntimeConfig().public.posthog;
+
+		if (config.disabled) {
+			return {
+				provide: {
+					posthog: null as PostHog | null,
+				},
+			};
+		}
+
+		const posthogFeatureFlags = useState<Record<string, boolean | string> | undefined>('ph-feature-flags');
+		const posthogFeatureFlagPayloads = useState<Record<string, JsonType> | undefined>('ph-feature-flag-payloads');
+
+		const clientOptions = defu<PostHogConfig, Partial<PostHogConfig>[]>(config.clientOptions ?? {}, {
+			api_host: config.host,
+			ui_host: '<ph_app_host>',
+			capture_pageview: false,
+			bootstrap: {
+				featureFlags: posthogFeatureFlags.value,
+				featureFlagPayloads: posthogFeatureFlagPayloads.value,
+			},
+			loaded: (posthog) => {
+				if (import.meta.env.MODE === 'development') posthog.debug();
+			},
+		});
+
+		const identity = useCookie(`ph_${config.publicKey}_posthog`, { default: () => '' }) as any;
+
+		clientOptions.bootstrap.distinctID = identity.value?.distinct_id ?? undefined;
+
+		const posthogClient = posthog.init(config.publicKey, clientOptions);
+
+		if (config.capturePageViews) {
+			// Make sure that pageviews are captured with each route change
+			const router = useRouter();
+
+			router.beforeEach(() => {
+				posthog.capture('$pageview');
+			});
+		}
+
+		posthog.onFeatureFlags((flags, featureFlags) => {
+			posthogFeatureFlags.value = featureFlags;
+
+			posthogFeatureFlagPayloads.value = flags.reduce<Record<string, JsonType>>((acc, flag) => {
+				acc[flag] = posthog.getFeatureFlagPayload(flag);
+				return acc;
+			}, {});
+		});
+
+		return {
+			provide: {
+				posthog: (posthogClient ? posthogClient : null) as PostHog | null,
+			},
+		};
+	},
+});
+
+declare module '#app' {
+	interface NuxtApp {
+		$posthog: PostHog | null;
+	}
+}
+
+declare module '@vue/runtime-core' {
+	interface ComponentCustomProperties {
+		$posthog: PostHog | null;
+	}
+}

--- a/modules/posthog/runtime/plugins/posthog.server.ts
+++ b/modules/posthog/runtime/plugins/posthog.server.ts
@@ -1,0 +1,44 @@
+import { defineNuxtPlugin, useRuntimeConfig, useState, useRequestEvent } from '#app';
+import { getCookie } from 'h3';
+import { PostHog } from 'posthog-node';
+import type { JsonType } from 'posthog-js';
+
+export default defineNuxtPlugin({
+	name: 'posthog-server',
+	enforce: 'pre',
+	setup: async () => {
+		const config = useRuntimeConfig().public.posthog;
+
+		const event = useRequestEvent();
+		const cookie = event ? getCookie(event, `ph_${config.publicKey}_posthog`) : undefined;
+		const identity = JSON.parse(cookie ?? '{}');
+		const distinctId = identity?.distinct_id ?? undefined;
+
+		if (config.disabled) {
+			return {
+				provide: {
+					serverPosthog: null as PostHog | null,
+				},
+			};
+		}
+
+		if (config.publicKey.length === 0) {
+			// PostHog public key is not defined. Skipping PostHog setup.
+			// User has already been warned on dev startup
+			return {};
+		}
+
+		const posthog = new PostHog(config.publicKey, { host: config.host });
+
+		const { featureFlags, featureFlagPayloads } = await posthog.getAllFlagsAndPayloads(distinctId);
+
+		useState<Record<string, boolean | string> | undefined>('ph-feature-flags', () => featureFlags);
+		useState<Record<string, JsonType> | undefined>('ph-feature-flag-payloads', () => featureFlagPayloads);
+
+		return {
+			provide: {
+				serverPosthog: posthog,
+			},
+		};
+	},
+});

--- a/modules/posthog/runtime/types/directives.d.ts
+++ b/modules/posthog/runtime/types/directives.d.ts
@@ -1,0 +1,40 @@
+import type { ObjectDirective } from 'vue';
+import type { Property } from 'posthog-js';
+
+declare global {
+	export interface CaptureEvent {
+		/**
+		 * Event name
+		 *
+		 * @docs https://posthog.com/docs/product-analytics/capture-events
+		 */
+		name: string;
+
+		/**
+		 * Event properties
+		 *
+		 * @docs https://posthog.com/docs/product-analytics/capture-events#setting-event-properties
+		 */
+		properties?: Record<string, Property>;
+	}
+
+	export interface CaptureModifiers {
+		/**
+		 * Click event modifier
+		 */
+		click?: boolean;
+
+		/**
+		 * Hover event modifier
+		 */
+		hover?: boolean;
+	}
+}
+
+declare module 'vue' {
+	export interface ComponentCustomProperties {
+		vCapture: ObjectDirective<HTMLElement, CaptureEvent | string>;
+	}
+}
+
+export {};

--- a/modules/posthog/runtime/types/index.d.ts
+++ b/modules/posthog/runtime/types/index.d.ts
@@ -1,0 +1,7 @@
+import type { ModuleOptions } from '../../module';
+
+declare module '@nuxt/schema' {
+	interface PublicRuntimeConfig {
+		posthog: ModuleOptions;
+	}
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,6 @@ export default defineNuxtConfig({
 		'@nuxt/scripts',
 		'@nuxtjs/seo',
 		'@vueuse/nuxt',
-		'nuxt-posthog',
 		...((process.env.ALGOLIA_APPLICATION_ID && process.env.ALGOLIA_API_KEY)
 			? ['@nuxtjs/algolia']
 			: []),
@@ -181,6 +180,9 @@ export default defineNuxtConfig({
 	// Disable PostHog in development
 	posthog: {
 		disabled: process.env.NODE_ENV === 'development',
+		clientOptions: {
+			person_profiles: 'always',
+		},
 	},
 
 	robots: {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
 		"@vueuse/nuxt": "13.3.0",
 		"lodash-es": "4.17.21",
 		"nuxt": "3.17.5",
-		"nuxt-posthog": "1.6.3",
 		"openapi3-ts": "4.4.0",
 		"sharp": "^0.34.2",
-		"ufo": "1.6.1"
+		"ufo": "1.6.1",
+		"posthog-js": "1.260.1",
+		"posthog-node": "5.7.0"
 	},
 	"devDependencies": {
 		"@nuxt/eslint": "1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,12 +60,15 @@ importers:
       nuxt:
         specifier: 3.17.5
         version: 3.17.5(@parcel/watcher@2.5.1)(@types/node@24.0.0)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.42.0)(terser@5.42.0)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(yaml@2.8.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.8.0)
-      nuxt-posthog:
-        specifier: 1.6.3
-        version: 1.6.3(magicast@0.3.5)
       openapi3-ts:
         specifier: 4.4.0
         version: 4.4.0
+      posthog-js:
+        specifier: 1.260.1
+        version: 1.260.1
+      posthog-node:
+        specifier: 5.7.0
+        version: 5.7.0
       sharp:
         specifier: ^0.34.2
         version: 0.34.2
@@ -1310,6 +1313,9 @@ packages:
   '@poppinss/exception@1.2.1':
     resolution: {integrity: sha512-aQypoot0HPSJa6gDPEPTntc1GT6QINrSbgRlRhadGW2WaYqUK3tK4Bw9SBMZXhmxd3GeAlZjVcODHgiu+THY7A==}
     engines: {node: '>=18'}
+
+  '@posthog/core@1.0.0':
+    resolution: {integrity: sha512-gquQld+duT9DdzLIFoHZkUMW0DZOTSLCtSjuuC/zKFz65Qecbz9p37DHBJMkw0dCuB8Mgh2GtH8Ag3PznJrP3g==}
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
@@ -4577,9 +4583,6 @@ packages:
       '@unhead/vue': ^2.0.5
       unstorage: ^1.15.0
 
-  nuxt-posthog@1.6.3:
-    resolution: {integrity: sha512-5uUlBITFMJjIxsAPo3gkB8+Yh5tUFSuBV4RQow2MD6B0uBz6wEACLnF28PGzlltnEHpMP26oUi3Si7qEIjhd7Q==}
-
   nuxt-schema-org@5.0.5:
     resolution: {integrity: sha512-OXV1WdSpyttiAgRicdtqMHYMNcgj7hcws2zRmgI9zMI/Rbs6z4/74aZLtSM3YNS/Bvbr9LcCSzYT6WJOvEB1Yg==}
     peerDependencies:
@@ -5006,8 +5009,8 @@ packages:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.249.5:
-    resolution: {integrity: sha512-ynB2bcSZz91xF36Aun2OgAvJ37WPjp8hrUHplZJTdJKhaX7j63CePR+Ved6NVO4YqwhCOVqepxwGGJXG4ROBeA==}
+  posthog-js@1.260.1:
+    resolution: {integrity: sha512-DD8ZSRpdScacMqtqUIvMFme8lmOWkOvExG8VvjONE7Cm3xpRH5xXpfrwMJE4bayTGWKMx4ij6SfphK6dm/o2ug==}
     peerDependencies:
       '@rrweb/types': 2.0.0-alpha.17
       rrweb-snapshot: 2.0.0-alpha.17
@@ -5017,9 +5020,9 @@ packages:
       rrweb-snapshot:
         optional: true
 
-  posthog-node@4.4.1:
-    resolution: {integrity: sha512-o9G9sSvwWITrfSJgIUrPLJd//AYPGJNu5D+pSLxqiBvhUeicc/i639FvU0DPr1OsHiLDE2zHNMmLpa0mw4kBCg==}
-    engines: {node: '>=15.0.0'}
+  posthog-node@5.7.0:
+    resolution: {integrity: sha512-6J1AIZWtbr2lEbZOO2AzO/h1FPJjUZM4KWcdaL2UQw7FY8J7VNaH3NiaRockASFmglpID7zEY25gV/YwCtuXjg==}
+    engines: {node: '>=20'}
 
   preact@10.26.8:
     resolution: {integrity: sha512-1nMfdFjucm5hKvq0IClqZwK4FJkGXhRrQstOQ3P4vp8HxKrJEMFcY6RdBRVTdfQS/UlnX6gfbPuTvaqx/bDoeQ==}
@@ -8160,6 +8163,8 @@ snapshots:
       supports-color: 10.0.0
 
   '@poppinss/exception@1.2.1': {}
+
+  '@posthog/core@1.0.0': {}
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -11830,18 +11835,6 @@ snapshots:
       - vite
       - vue
 
-  nuxt-posthog@1.6.3(magicast@0.3.5):
-    dependencies:
-      '@nuxt/kit': 3.17.5(magicast@0.3.5)
-      defu: 6.1.4
-      posthog-js: 1.249.5
-      posthog-node: 4.4.1
-    transitivePeerDependencies:
-      - '@rrweb/types'
-      - debug
-      - magicast
-      - rrweb-snapshot
-
   nuxt-schema-org@5.0.5(@unhead/vue@2.0.10(vue@3.5.16(typescript@5.8.3)))(magicast@0.3.5)(vue@3.5.16(typescript@5.8.3)):
     dependencies:
       '@nuxt/kit': 3.17.5(magicast@0.3.5)
@@ -12420,18 +12413,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.249.5:
+  posthog-js@1.260.1:
     dependencies:
       core-js: 3.43.0
       fflate: 0.4.8
       preact: 10.26.8
       web-vitals: 4.2.4
 
-  posthog-node@4.4.1:
+  posthog-node@5.7.0:
     dependencies:
-      axios: 1.9.0
-    transitivePeerDependencies:
-      - debug
+      '@posthog/core': 1.0.0
 
   preact@10.26.8: {}
 


### PR DESCRIPTION
This pull request replaces the external `nuxt-posthog` module with an in-repo PostHog integration for Nuxt while updating dependencies to use the latest PostHog libraries. The changes ensure that we are using the same configuration across the marketing properties, which currently use different versions/configs.

* Removed `nuxt-posthog` from dependencies and added direct dependencies on `posthog-js` and `posthog-node` (with updated versions).
* Updated `nuxt.config.ts` to remove the external module and configure person profiles to always be made (BUG).
* Copied the PostHog module used in https://github.com/directus/website to the docs, so it is consistent