### PR TITLE
Document `version` and `versionRaw` parameters along with `version` breaking changes

### DIFF
--- a/content/guides/04.connect/3.query-parameters.md
+++ b/content/guides/04.connect/3.query-parameters.md
@@ -533,6 +533,61 @@ Saves the API response to a file. Valid values are `csv`, `json`, `xml`, `yaml`.
 ?export=type
 ```
 
+## Version
+
+Queries a version of a record by version key when [content versioning](/guides/content/content-versioning) is enabled on a collection. Applies only to single item retrieval.
+
+```http [GET /items/posts/1]
+?version=v1
+```
+
+```graphql [GraphQL]
+query {
+  posts_by_id(id: 1, version: "v1") {
+    id
+  }
+}
+```
+
+```js [SDK]
+import { createDirectus, rest, readItem } from "@directus/sdk";
+const directus = createDirectus("https://directus.example.com").with(rest());
+
+const result = await directus.request(
+  readItem("posts", {
+    version: "v1",
+  })
+);
+```
+
+## VersionRaw
+
+Specifies to return relational delta changes as a [detailed output](https://directus.io/docs/guides/connect/relations#creating-updating-deleting) on a version record.
+
+```http [GET /items/posts/1]
+?version=v1&versionRaw=true
+```
+
+```graphql [GraphQL]
+query {
+  posts_by_version(id: 1, version: "v1") {
+    id
+  }
+}
+```
+
+```js [SDK]
+import { createDirectus, rest, readItem } from "@directus/sdk";
+const directus = createDirectus("https://directus.example.com").with(rest());
+
+const result = await directus.request(
+  readItem("posts", {
+    version: "v1",
+    versionRaw: true,
+  })
+);
+```
+
 ## Functions
 
 :partial{content="query-functions"}

--- a/content/releases/3.breaking-changes/2.version-11.md
+++ b/content/releases/3.breaking-changes/2.version-11.md
@@ -7,22 +7,22 @@ description: Breaking changes may require action on your part before upgrading.
 
 #### Content Versioning
 
-Content Versioning has been updated to properly merge relational data and support all query paramaters.
+Content Versioning has been updated to correctly return deeply nested relational data and support all query parameters when requesting a version of an item.
 
 Due to these changes the following breaking changes and caveats should be noted:
 
-**Breaking Change**
+**Breaking Changes**
 
 1. Relational versioned data now requires explicit field expansion to be included in the response.
-2. Invalid data (e.g. Fails validation rules) will error on query.
+2. Invalid data (e.g. Fails validation rules) will now error on query.
 3. Query parameters now apply to the versioned data instead of the main record, this applies to relational data as well.
 
 **Caveat**
 
-1. A merged relational object combining the main and current version is now returned. Permissions are accounted for during the merge process.
+1. A merged relational object combining the main and current version is now returned. Permissions and validations are accounted for during the merge process.
 2. New relational records will return with an `id` of null until promoted to main.
-3. Due to the use of transactions deadlocking may occur during the query process.
-4. Due to the use of transactions any sqlite will block any requests taking place during a version request.
+3. Due to the use of database transactions under the hood, deadlocking may occur when querying a version of an item.
+4. When using SQLite, the above mentioned database transactions will temporarily block all other requests when querying a version of an item.
 
 ## Version 11.10.1
 

--- a/content/releases/3.breaking-changes/2.version-11.md
+++ b/content/releases/3.breaking-changes/2.version-11.md
@@ -3,6 +3,27 @@ title: Version 11
 description: Breaking changes may require action on your part before upgrading.
 ---
 
+## Version 11.11.0
+
+#### Content Versioning
+
+Content Versioning has been updated to properly merge relational data and support all query paramaters.
+
+Due to these changes the following breaking changes and caveats should be noted:
+
+**Breaking Change**
+
+1. Relational versioned data now requires explicit field expansion to be included in the response.
+2. Invalid data (e.g. Fails validation rules) will error on query.
+3. Query parameters now apply to the versioned data instead of the main record, this applies to relational data as well.
+
+**Caveat**
+
+1. A merged relational object combining the main and current version is now returned. Permissions are accounted for during the merge process.
+2. New relational records will return with an `id` of null until promoted to main.
+3. Due to the use of transactions deadlocking may occur during the query process.
+4. Due to the use of transactions any sqlite will block any requests taking place during a version request.
+
 ## Version 11.10.1
 
 #### Typed services for API extensions using TypeScript


### PR DESCRIPTION
This PR adds missing documentation for the version and versionRaw query parameters and includes details on recent breaking changes to [content versioning](https://github.com/directus/directus/pull/25437)

Fixes https://github.com/directus/docs/issues/427 
