### PR TITLE
Fix typo in deep description

### DIFF
--- a/content/guides/04.connect/3.query-parameters.md
+++ b/content/guides/04.connect/3.query-parameters.md
@@ -399,7 +399,7 @@ const result = await directus.request(
 
 ## Deep
 
-Deep allows you to set any of the other query parameters (expect for [Fields](#fields) and [Deep](#deep) itself) on a nested relational dataset.
+Deep allows you to set any of the other query parameters (except for [Fields](#fields) and [Deep](#deep) itself) on a nested relational dataset.
 
 The nested query parameters are to be prefixed with an underscore.
 


### PR DESCRIPTION
Fixed typo in deep description, should be `except`, not `expect`