### PR TITLE
Fix typo in the docu "Advanced Types with the Directus SDK"

### DIFF
--- a/content/tutorials/3.tips-and-tricks/advanced-types-with-the-directus-sdk.md
+++ b/content/tutorials/3.tips-and-tricks/advanced-types-with-the-directus-sdk.md
@@ -25,7 +25,7 @@ The root schema type is the type provided to the SDK client. It should contain *
 junction collections for many-to-many and many-to-any relations. This type is used by the SDK as a lookup table to
 determine what relations exist.
 
-If a collection if defined as an array, it is considered a regular collection with multiple items. If not defined as an
+If a collection is defined as an array, it is considered a regular collection with multiple items. If not defined as an
 array, but instead as a single type, the collection is considered to be a singleton.
 
 ```ts


### PR DESCRIPTION
Noticed a small typo while checking the documentation on "Advanced Types with the Directus SDK".