### PR TITLE
docs: update Node.js version reference in dev environment guide

### DIFF
--- a/content/community/3.codebase/2.dev-environment.md
+++ b/content/community/3.codebase/2.dev-environment.md
@@ -12,7 +12,7 @@ This is specifically for contributing to the codebase of Directus. To run Direct
 
 ## Requirements
 
-You will need to have [version 18 of Node.js](https://nodejs.org/en/download) for the development environment of Directus.
+You will need to have the [current LTS version of Node.js](https://nodejs.org/en/download) for the development environment of Directus. Check the `engines.node` field in the [main repository's package.json](https://github.com/directus/directus/blob/main/package.json) for the exact version requirement.
 
 You will also need to have the package manager [pnpm](https://pnpm.io) installed. It's recommended to install [pnpm via Corepack](https://pnpm.io/installation#using-corepack) for automatic use of the correct version.
 


### PR DESCRIPTION
- Remove hardcoded Node.js version 18 reference
- Add dynamic reference to main repo's package.json engines.node field
- Ensures documentation stays current without manual updates
- Fixes outdated version requirement (actual requirement is Node.js 22+)