### PR TITLE
Add config intro page

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -109,7 +109,7 @@ export default defineAppConfig({
 					},
 					{
 						label: 'Configuration',
-						to: '/configuration/general',
+						to: '/configuration/intro',
 						icon: 'i-ph-gear',
 					},
 				],

--- a/content/configuration/0.intro.md
+++ b/content/configuration/0.intro.md
@@ -161,9 +161,7 @@ module.exports = function (env) {
 
 ## Environment Variable Files
 
-Any of the environment variable values can be imported from a file, by appending `_FILE` to the directus environment variable
-name. This is especially useful when used in conjunction with Docker Secrets, so you can keep sensitive data out of your
-compose files. For example:
+Any of the environment variable values can be imported from a file, by appending `_FILE` to a [Directus environment variable name](https://github.com/directus/directus/blob/main/packages/env/src/constants/directus-variables.ts). This is especially useful when used in conjunction with Docker Secrets, so you can keep sensitive data out of your compose files. For example:
 
 ```
 DB_PASSWORD_FILE="/run/secrets/db_password"

--- a/content/configuration/0.intro.md
+++ b/content/configuration/0.intro.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration Options
+title: Introduction
 description:
   Environment variables are used for all configuration within a Directus project. These variables can be defined in a
   number of ways, which we cover below.

--- a/content/configuration/0.intro.md
+++ b/content/configuration/0.intro.md
@@ -165,7 +165,7 @@ module.exports = function (env) {
 
 ## Environment Variable Files
 
-Any of the environment variable values can be imported from a file, by appending `_FILE` to the environment variable
+Any of the environment variable values can be imported from a file, by appending `_FILE` to the directus environment variable
 name. This is especially useful when used in conjunction with Docker Secrets, so you can keep sensitive data out of your
 compose files. For example:
 

--- a/content/configuration/0.intro.md
+++ b/content/configuration/0.intro.md
@@ -96,8 +96,7 @@ By default, the file is expected to be a ESM, while CommonJS is supported too by
 The JavaScript configuration supports two different formats, either an **Object Structure** where the key is the
 environment variable name:
 
-::: code-group
-
+::code-group
 ```js [config.js]
 export default {
   HOST: "0.0.0.0",
@@ -123,14 +122,12 @@ module.exports = {
   // etc
 };
 ```
-
-:::
+::
 
 Or a **Function Structure** that _returns_ the same object format as above. The function gets `process.env` as its
 parameter.
 
-::: code-group
-
+::code-group
 ```js [config.js]
 export default function (env) {
   return {
@@ -160,8 +157,7 @@ module.exports = function (env) {
   };
 };
 ```
-
-:::
+::
 
 ## Environment Variable Files
 

--- a/content/configuration/0.intro.md
+++ b/content/configuration/0.intro.md
@@ -1,0 +1,226 @@
+---
+title: Configuration Options
+description:
+  Environment variables are used for all configuration within a Directus project. These variables can be defined in a
+  number of ways, which we cover below.
+---
+
+# Configuration Options
+
+> Environment variables are used for all configuration within a Directus project. These variables can be defined in a
+> number of ways, which we cover below.
+
+## Configuration Files
+
+By default, Directus will read the `.env` file located next to your project's `package.json` (typically in the root
+folder of your project) for its configuration. You can change this path and filename by setting the `CONFIG_PATH`
+environment variable before starting Directus. For example:
+
+```bash
+CONFIG_PATH="/path/to/config.js" npx directus start
+```
+
+In case you prefer using a configuration file instead of environment variables, you can also use the `CONFIG_PATH`
+environment variable to instruct Directus to use a local configuration file instead of environment variables. The config
+file can be one of the following formats:
+
+- [.env](#env)
+- [config.json](#config-json)
+- [config.yaml](#config-yaml)
+- [config.js](#config-js)
+
+### .env
+
+If the config path has no file extension, or a file extension that's not one of the other supported formats, Directus
+will try reading the file config path as environment variables. This has the following structure:
+
+```
+HOST="0.0.0.0"
+PORT=8055
+
+DB_CLIENT="pg"
+DB_HOST="localhost"
+DB_PORT=5432
+
+etc
+```
+
+### config.json
+
+If you prefer a single JSON file for your configuration, create a JSON file with the environment variables as keys, for
+example:
+
+```
+CONFIG_PATH="/path/to/config.json"
+```
+
+```json
+{
+  "HOST": "0.0.0.0",
+  "PORT": 8055,
+
+  "DB_CLIENT": "pg",
+  "DB_HOST": "localhost",
+  "DB_PORT": 5432
+
+  // etc
+}
+```
+
+### config.yaml
+
+Similar to JSON, you can use a `.yaml` (or `.yml`) file for your config:
+
+```
+CONFIG_PATH="/path/to/config.yaml"
+```
+
+```yaml
+HOST: 0.0.0.0
+PORT: 8055
+
+DB_CLIENT: pg
+DB_HOST: localhost
+DB_PORT: 5432
+#
+# etc
+```
+
+### config.js
+
+Using a JavaScript file for your config allows you to dynamically generate the configuration of the project during
+startup.
+
+By default, the file is expected to be a ESM, while CommonJS is supported too by using `.cjs` as the file extension.
+
+The JavaScript configuration supports two different formats, either an **Object Structure** where the key is the
+environment variable name:
+
+::: code-group
+
+```js [config.js]
+export default {
+  HOST: "0.0.0.0",
+  PORT: 8055,
+
+  DB_CLIENT: "pg",
+  DB_HOST: "localhost",
+  DB_PORT: 5432,
+
+  // etc
+};
+```
+
+```js [config.cjs]
+module.exports = {
+  HOST: "0.0.0.0",
+  PORT: 8055,
+
+  DB_CLIENT: "pg",
+  DB_HOST: "localhost",
+  DB_PORT: 5432,
+
+  // etc
+};
+```
+
+:::
+
+Or a **Function Structure** that _returns_ the same object format as above. The function gets `process.env` as its
+parameter.
+
+::: code-group
+
+```js [config.js]
+export default function (env) {
+  return {
+    HOST: "0.0.0.0",
+    PORT: 8055,
+
+    DB_CLIENT: "pg",
+    DB_HOST: "localhost",
+    DB_PORT: 5432,
+
+    // etc
+  };
+}
+```
+
+```js [config.cjs]
+module.exports = function (env) {
+  return {
+    HOST: "0.0.0.0",
+    PORT: 8055,
+
+    DB_CLIENT: "pg",
+    DB_HOST: "localhost",
+    DB_PORT: 5432,
+
+    // etc
+  };
+};
+```
+
+:::
+
+## Environment Variable Files
+
+Any of the environment variable values can be imported from a file, by appending `_FILE` to the environment variable
+name. This is especially useful when used in conjunction with Docker Secrets, so you can keep sensitive data out of your
+compose files. For example:
+
+```
+DB_PASSWORD_FILE="/run/secrets/db_password"
+```
+
+## Type Casting and Nesting
+
+Environment variables are automatically type cast based on the structure of the variable, for example:
+
+```
+PUBLIC_URL="https://example.com"
+// "https://example.com"
+
+DB_HOST="3306"
+// 3306
+
+CORS_ENABLED="false"
+// false
+
+STORAGE_LOCATIONS="s3,local,example"
+// ["s3", "local", "example"]
+```
+
+In cases where the environment variables are converted to a configuration object for third party library use, like in
+`DB_*` or `REDIS_*`, the environment variable will be converted to camelCase. You can use a double underscore (`__`) for
+nested objects:
+
+```
+DB_CLIENT="pg"
+DB_CONNECTION_STRING="postgresql://postgres:example@127.0.0.1"
+DB_SSL__REJECT_UNAUTHORIZED="false"
+
+{
+	client: "pg",
+	connectionString: "postgresql://postgres:example@127.0.0.1",
+	ssl: {
+		rejectUnauthorized: false
+	}
+}
+```
+
+## Environment Syntax Prefix
+
+Directus will attempt to [automatically type cast environment variables](#type-casting-and-nesting) based on context
+clues. If you have a specific need for a given type, you can tell Directus what type to use for the given value by
+prefixing the value with `{type}:`. The following types are available:
+
+| Syntax Prefix | Example                                                                                                         | Output                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `string`      | `string:value`                                                                                                  | `"value"`                                                                                            |
+| `number`      | `number:3306`                                                                                                   | `3306`                                                                                               |
+| `regex`       | `regex:\.example\.com$`                                                                                         | `/\.example\.com$/`                                                                                  |
+| `array`       | `array:https://example.com,https://example2.com` <br> `array:string:https://example.com,regex:\.example3\.com$` | `["https://example.com", "https://example2.com"]` <br> `["https://example.com", /\.example3\.com$/]` |
+| `json`        | `json:{"items": ["example1", "example2"]}`                                                                      | `{"items": ["example1", "example2"]}`                                                                |
+
+Explicit casting is also available when reading from a file with the `_FILE` suffix.

--- a/content/index.md
+++ b/content/index.md
@@ -270,7 +270,7 @@ navigation: false
   title: Environment Variables
   description: Configure Directus at an advanced level.
   icon: heroicons-outline:cog
-  to: '/configuration/general'
+  to: '/configuration/intro'
   ---
   :::
 


### PR DESCRIPTION
This PR add the missing `Configuration Files`, `Environment Variable Files`, `Type Casting and Nesting` and `Environment Syntax Prefix` sections from the old docs. These sections explain what options users have for config files and formats as well as documents our auto casting functionality. 

It was added as an intro section to the configuration page as that looked to be the most appropriate location.

Changes were copied directly [from the original](https://github.com/directus/legacy-docs/blob/main/self-hosted/config-options.md) with the exception of cef2f382b60cf293d063712621ca23096e98ec2b, to clarify usage due to https://github.com/directus/directus/issues/25856

---
Fixes: #412