### PR TITLE
Replace `node-schedule` with `cron`

### DIFF
--- a/content/guides/06.automate/3.triggers.md
+++ b/content/guides/06.automate/3.triggers.md
@@ -94,7 +94,7 @@ finish and return whatever value is in **Response Body**. This slows the API, bu
 ![Schedule CRON trigger setup](/img/f5f5d71c-462f-4a45-a6bc-6ad1ed3a8462.webp)
 
 This trigger type enables creating data at scheduled intervals, via
-[6-point cron job syntax](https://github.com/node-schedule/node-schedule#cron-style-scheduling).
+[6-point cron job syntax](https://github.com/kelektiv/node-cron#readme).
 
 - **Interval** — Set the cron job interval to schedule when the Flow triggers.
 


### PR DESCRIPTION
This PR updates the cron library URL following the migration from `node-schedule` to `cron` in the Directus core.

----
Related core PR: https://github.com/directus/directus/pull/25874
