### PR TITLE
Fix incorrect Timestamp/DateTime timezone documentation

### DIFF
--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -160,9 +160,8 @@ Date picker input that allows user to select a date and time.
 
 ::callout{icon="material-symbols:info-outline"}
 **Handling Timezones**
-`Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g., `2024-01-15T09:00:00.000Z`).
-
-`DateTime` stores values without timezone information and returns them in ISO 8601 format. The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable (e.g., `2024-01-15T10:00:00`).
+- `Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g., `2024-01-15T09:00:00.000Z`).
+- `DateTime` stores values without timezone information and returns them in ISO 8601 format. The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable (e.g., `2024-01-15T10:00:00`).
 
 System fields `date_created` and `date_updated` use `Timestamp`.
 ::

--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -160,7 +160,7 @@ Date picker input that allows user to select a date and time.
 
 ::callout{icon="material-symbols:info-outline"}
 **Handling Timezones**
-- `Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g., `2024-01-15T09:00:00.000Z`).
+- `Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g. "2024-01-15T09:00:00.000Z").
 - `DateTime` stores values without timezone information and returns them in ISO 8601 format (e.g., `2024-01-15T10:00:00`). The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable.
 
 System fields `date_created` and `date_updated` use `Timestamp`.

--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -160,7 +160,11 @@ Date picker input that allows user to select a date and time.
 
 ::callout{icon="material-symbols:info-outline"}
 **Handling Timezones**
-The `DateTime` type does not have timezone information, and will always store values as UTC. The `Timestamp` type contains timezone information.
+`Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g., `2024-01-15T09:00:00.000Z`).
+
+`DateTime` stores values without timezone information and returns them in ISO 8601 format. The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable (e.g., `2024-01-15T10:00:00`).
+
+System fields `date_created` and `date_updated` use `Timestamp`.
 ::
 
 ### Repeater

--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -160,8 +160,8 @@ Date picker input that allows user to select a date and time.
 
 ::callout{icon="material-symbols:info-outline"}
 **Handling Timezones**
-- `Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g. "2024-01-15T09:00:00.000Z").
-- `DateTime` stores values without timezone information and returns them in ISO 8601 format (e.g., `2024-01-15T10:00:00`). The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable.
+- `Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g. 2024-01-15T09:00:00.000Z).
+- `DateTime` stores values without timezone information and returns them in ISO 8601 format (e.g. 2024-01-15T10:00:00). The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable.
 
 System fields `date_created` and `date_updated` use `Timestamp`.
 ::

--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -161,7 +161,7 @@ Date picker input that allows user to select a date and time.
 ::callout{icon="material-symbols:info-outline"}
 **Handling Timezones**
 - `Timestamp` normalizes values to UTC and returns them in ISO 8601 format with the `Z` suffix (e.g., `2024-01-15T09:00:00.000Z`).
-- `DateTime` stores values without timezone information and returns them in ISO 8601 format. The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable (e.g., `2024-01-15T10:00:00`).
+- `DateTime` stores values without timezone information and returns them in ISO 8601 format (e.g., `2024-01-15T10:00:00`). The stored value depends on the database vendor's format and database timezone, while the returned value is dependent on the server's `TZ` environment variable.
 
 System fields `date_created` and `date_updated` use `Timestamp`.
 ::


### PR DESCRIPTION

- Timestamp: normalizes to UTC, returns with Z suffix
- DateTime: depends on DB and server TZ configuration
- Clarify system fields use Timestamp

related to core [issue](https://github.com/directus/directus/issues/26371)