### PR TITLE
Document new SERVER_SIDE_ENCRYPTION_KMS_KEY_ID option for s3

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -3,7 +3,6 @@ title: Files
 description: Configuration for storage locations, metadata, upload limits, and transformations.
 ---
 
-
 :partial{content="config-env-vars"}
 
 By default, Directus stores all uploaded files locally on the file system or can also configure Directus to use external storage services. You can also configure _multiple_ storage adapters at the same time which allows you to choose where files are being uploaded on a file-by-file basis.
@@ -34,20 +33,21 @@ Based on your configured drivers, you must also provide additional variables, wh
 
 ### S3 (`s3`)
 
-| Variable                                    | Description                | Default Value      |
-| ------------------------------------------- | -------------------------- | ------------------ |
-| `STORAGE_<LOCATION>_KEY`                    | User key.                  |                    |
-| `STORAGE_<LOCATION>_SECRET`                 | User secret.               |                    |
-| `STORAGE_<LOCATION>_BUCKET`                 | S3 bucket.                 |                    |
-| `STORAGE_<LOCATION>_REGION`                 | S3 region.                 |                    |
-| `STORAGE_<LOCATION>_ENDPOINT`<sup>[1]</sup> | S3 endpoint.               | `s3.amazonaws.com` |
-| `STORAGE_<LOCATION>_ACL`                    | S3 ACL.                    |                    |
-| `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION` | S3 server side encryption. |                    |
-| `STORAGE_<LOCATION>_FORCE_PATH_STYLE`       | S3 force path style.       | false              |
-| `STORAGE_<LOCATION>_CONNECTION_TIMEOUT`     | S3 connection timeout (ms).| 5000               |
-| `STORAGE_<LOCATION>_SOCKET_TIMEOUT`         | S3 socket timeout (ms).    | 120000             |
-| `STORAGE_<LOCATION>_MAX_SOCKETS`            | S3 max sockets.            | 500                |
-| `STORAGE_<LOCATION>_KEEP_ALIVE`             | S3 keep alive.             | true               |
+| Variable                                               | Description                       | Default Value      |
+| ------------------------------------------------------ | --------------------------------- | ------------------ |
+| `STORAGE_<LOCATION>_KEY`                               | User key.                         |                    |
+| `STORAGE_<LOCATION>_SECRET`                            | User secret.                      |                    |
+| `STORAGE_<LOCATION>_BUCKET`                            | S3 bucket.                        |                    |
+| `STORAGE_<LOCATION>_REGION`                            | S3 region.                        |                    |
+| `STORAGE_<LOCATION>_ENDPOINT`<sup>[1]</sup>            | S3 endpoint.                      | `s3.amazonaws.com` |
+| `STORAGE_<LOCATION>_ACL`                               | S3 ACL.                           |                    |
+| `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION`            | S3 server side encryption.        |                    |
+| `STORAGE_<LOCATION>_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID` | S3 server side encryption kms id. |                    |
+| `STORAGE_<LOCATION>_FORCE_PATH_STYLE`                  | S3 force path style.              | false              |
+| `STORAGE_<LOCATION>_CONNECTION_TIMEOUT`                | S3 connection timeout (ms).       | 5000               |
+| `STORAGE_<LOCATION>_SOCKET_TIMEOUT`                    | S3 socket timeout (ms).           | 120000             |
+| `STORAGE_<LOCATION>_MAX_SOCKETS`                       | S3 max sockets.                   | 500                |
+| `STORAGE_<LOCATION>_KEEP_ALIVE`                        | S3 keep alive.                    | true               |
 
 <sup>[1]</sup> When overriding this variable for S3, make sure to add your bucket's region in the endpoint: `s3.{region}.amazonaws.com`.
 


### PR DESCRIPTION
This PR documents the new sse kms id option added for s3 in https://github.com/directus/directus/pull/26377/changes