### PR TITLE
Update instructions for accessing the activity feed

### DIFF
--- a/content/guides/03.auth/6.accountability.md
+++ b/content/guides/03.auth/6.accountability.md
@@ -7,7 +7,7 @@ description: Learn to audit user activity and enforce accountability using the a
 
 The activity feed provides a collective timeline of all data-changing actions taken within your project. It is accessed via the notifications tray of the sidebar, and has the same filtering and search features as the [Collection Page](/guides/data-model/collections).
 
-You can access the activity feed through the 🔔 Notifications section in the bottom left.
+The activity feed can be accessed via the notification drawer (:icon{name="heroicons-outline:bell" title="Bell"} icon) located in the bottom-left corner.
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
 **External Changes**

--- a/content/guides/03.auth/6.accountability.md
+++ b/content/guides/03.auth/6.accountability.md
@@ -7,7 +7,7 @@ description: Learn to audit user activity and enforce accountability using the a
 
 The activity feed provides a collective timeline of all data-changing actions taken within your project. It is accessed via the notifications tray of the sidebar, and has the same filtering and search features as the [Collection Page](/guides/data-model/collections).
 
-The activity feed can be accessed via the notification drawer (:icon{name="heroicons-outline:bell" title="Bell"} icon) located in the bottom-left corner.
+The activity feed can be accessed via the notification drawer (:icon{name="heroicons-outline:bell" title="Bell"}) located in the bottom-left corner.
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
 **External Changes**

--- a/content/guides/03.auth/6.accountability.md
+++ b/content/guides/03.auth/6.accountability.md
@@ -7,7 +7,7 @@ description: Learn to audit user activity and enforce accountability using the a
 
 The activity feed provides a collective timeline of all data-changing actions taken within your project. It is accessed via the notifications tray of the sidebar, and has the same filtering and search features as the [Collection Page](/guides/data-model/collections).
 
-You can access the activity feed from the bottom of the right-hand sidebar.
+You can access the activity feed through the 🔔 Notifications section in the bottom left.
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
 **External Changes**

--- a/content/guides/03.auth/6.accountability.md
+++ b/content/guides/03.auth/6.accountability.md
@@ -7,7 +7,7 @@ description: Learn to audit user activity and enforce accountability using the a
 
 The activity feed provides a collective timeline of all data-changing actions taken within your project. It is accessed via the notifications tray of the sidebar, and has the same filtering and search features as the [Collection Page](/guides/data-model/collections).
 
-The activity feed can be accessed via the notification drawer (:icon{name="heroicons-outline:bell" title="Bell"}) located in the bottom-left corner.
+The activity feed can be accessed via the notifications drawer (:icon{name="heroicons-outline:bell" title="Bell"}) located in the bottom-left corner.
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
 **External Changes**


### PR DESCRIPTION
Seems Activity Feed moved.

Stretch goal (less important): would be nice to update the screenshots, as they show Activity Feed linked in the bottom right but it's not there.