### PR TITLE
Document password reset limitation for external auth providers

### DIFF
--- a/content/guides/03.auth/4.email-login.md
+++ b/content/guides/03.auth/4.email-login.md
@@ -229,7 +229,7 @@ const result = await client.logout({ mode: "session" });
 
 ## Password Reset
 
-Requesting a password reset will send an email to the user with a URL to the Data Studio to reset their password.
+Requesting a password reset will send an email to the user with a URL to the Data Studio to reset their password. Password reset is only available for users using the default authentication provider. Users authenticated through external providers (OAuth, SAML, LDAP, etc.) will not receive a reset email.
 
 ```json [REST]
 // POST /auth/password/request


### PR DESCRIPTION
## Summary
- Added note that password reset is only available for users using the default authentication provider
- External provider users (OAuth, SAML, LDAP, etc.) will not receive a reset email

Related: https://github.com/directus/directus/pull/26627

🤖 Generated with [Claude Code](https://claude.com/claude-code)