### PR TITLE
Add error prop for login hook

### DIFF
--- a/content/guides/09.extensions/2.api-extensions/1.hooks.md
+++ b/content/guides/09.extensions/2.api-extensions/1.hooks.md
@@ -16,13 +16,13 @@ The `index.js` or `index.ts` file exports a function that is read by Directus. I
 
 ```js
 export default ({ filter, action }) => {
-	filter('items.create', () => {
-		console.log('Creating Item!');
-	});
+  filter("items.create", () => {
+    console.log("Creating Item!");
+  });
 
-	action('items.create', () => {
-		console.log('Item created!');
-	});
+  action("items.create", () => {
+    console.log("Item created!");
+  });
 };
 ```
 
@@ -55,11 +55,11 @@ Filter events are called before an event is emitted.
 
 ```js
 export default ({ filter }) => {
-	filter('items.create', (payload, meta, context) => {
-		console.log('About to create item.');
+  filter("items.create", (payload, meta, context) => {
+    console.log("About to create item.");
     return payload;
-	});
-}
+  });
+};
 ```
 
 The `filter` register function takes an event name and a callback function that receives the modifiable `payload`, an event-specific `meta` object, and a `context` object when the event is emitted.
@@ -88,7 +88,7 @@ The context object has the following properties:
 | `request.not_found`            | `false`                               | `request`, `response`                       |
 | `request.error`                | The request errors.                   |                                             |
 | `database.error`               | The database error.                   | `client`                                    |
-| `auth.login`                   | The login payload.                    | `status`, `user`, `provider`                |
+| `auth.login`                   | The login payload.                    | `status`, `user`, `provider`, `error`       |
 | `auth.jwt`                     | The auth token.                       | `status`, `user`, `provider`, `type`        |
 | `auth.create`<sup>[1]</sup>    | The created user.                     | `identifier`, `provider`, `providerPayload` |
 | `auth.update`<sup>[2]</sup>    | The updated auth token<sup>[3]</sup>. | `identifier`, `provider`, `providerPayload` |
@@ -127,10 +127,10 @@ Action events are called after an event is emitted.
 
 ```js
 export default ({ action }) => {
-	action('items.create', (meta, context) => {
-		console.log('Item was just created.');
-	});
-}
+  action("items.create", (meta, context) => {
+    console.log("Item was just created.");
+  });
+};
 ```
 
 The `action` register function takes an event name and a callback function that receives a `meta` object (containing information about the action and the payload) and a `context` object.
@@ -197,9 +197,9 @@ Init events are called during the Directus application lifecycle.
 
 ```js
 export default ({ init }) => {
-	init('routes.before', (meta) => {
-		console.log(meta);
-	});
+  init("routes.before", (meta) => {
+    console.log(meta);
+  });
 };
 ```
 
@@ -228,9 +228,9 @@ Schedule events are called on a defined time interval.
 
 ```js
 export default ({ schedule }) => {
-	schedule('*/15 * * * *', () => {
-		console.log('15 minutes have passed.');
-	});
+  schedule("*/15 * * * *", () => {
+    console.log("15 minutes have passed.");
+  });
 };
 ```
 
@@ -254,7 +254,7 @@ The embed hook injects custom JavaScript or CSS into the `<head>` and `<body>` t
 
 ```js
 export default ({ embed }) => {
-	embed('body', '<script>console.log("Hello World")</script>');
+  embed("body", '<script>console.log("Hello World")</script>');
 };
 ```
 
@@ -270,10 +270,9 @@ You can import the `SandboxHookRegisterContext` type from `directus:api` to type
 
 ```ts
 /// <reference types="@directus/extensions/api.d.ts" />
-import type { SandboxHookRegisterContext } from 'directus:api';
+import type { SandboxHookRegisterContext } from "directus:api";
 
-export default ({ filter, action }: SandboxHookRegisterContext) => {
-};
+export default ({ filter, action }: SandboxHookRegisterContext) => {};
 ```
 
 ::callout{icon="material-symbols:menu-book-outline" color="primary" to="/guides/extensions/api-extensions/sandbox"}


### PR DESCRIPTION
The `auth.login` event hook now accepts an error prop to provide some extra context when logins fail