### PR TITLE
vev ← Add version support and permission docs for Visual Editor

### DIFF
--- a/content/guides/02.content/5.live-preview.md
+++ b/content/guides/02.content/5.live-preview.md
@@ -25,7 +25,12 @@ If you're using a static site generator to preview your item data, be sure to de
 
 ::callout{icon="material-symbols:info-outline"}
 **Using Live Preview with Content Versioning**
-If you've enabled [content versioning](/guides/content/content-versioning), you can pass the version identifier to your live preview URL.
+If you've enabled [content versioning](/guides/content/content-versioning), you can pass the version identifier to your live preview URL. The version identifier also ensures that edits made via visual editing are saved to the selected version instead of the main item. However, your website must read this parameter and fetch versioned content using the `version` query parameter on the [items endpoint](/api/items) (e.g. `/items/posts/42?version=draft`). Without this, the preview will display main content regardless of the selected version.
+::
+
+::callout{icon="material-symbols:info-outline"}
+**Visual Editing in Live Preview with Versions**
+If your frontend is configured with the [Visual Editor Frontend Library](/guides/content/visual-editor/frontend-library) and a matching [Visual Editor URL](/guides/content/visual-editor/studio-module#version-support-in-urls) includes `{{$version}}`, visual editing in the live preview pane also works with content versions. When viewing a version, only items on collections with versioning enabled will show editable elements.
 ::
 
 ## Previewing Item Contents in the Editor

--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -110,13 +110,13 @@ our [API reference documentation](/api/versions).
 
 ## Configuring Visual Editor for Versions
 
-To enable version-aware previewing in the Visual Editor:
+To enable version support in the Visual Editor:
 
-1. Navigate to **Settings** > **Data Model** and select your collection
-2. In the Visual Editor settings, configure your preview URL to include the `version` variable
-3. Example preview URL: `https://your-site.com/preview?item={{id}}&version={{version}}`
+1. Navigate to **Settings → Visual Editor**
+2. Configure your URL to include the `{{$version}}` template variable
+3. Example URL: `https://your-site.com/preview?version={{$version}}`
 
-The Visual Editor will automatically pass the active version to your preview, allowing you to see draft changes in the context of your actual site layout.
+The `{{$version}}` variable passes the selected version key to your website and ensures that edits are saved to the selected version. Your website must read this parameter and fetch versioned content using the `version` query parameter on the [items endpoint](/api/items). See the [Studio Module documentation](/guides/content/visual-editor/studio-module#version-support-in-urls) for details.
 
 
 ## Revisions and Content Versioning

--- a/content/guides/02.content/8.visual-editor/1.frontend-library.md
+++ b/content/guides/02.content/8.visual-editor/1.frontend-library.md
@@ -125,6 +125,20 @@ Connecting your local development environment to a Directus Cloud Starter or Pro
 - Creating and using your own SSL certificate. In the case of Vite this can be done with an [SSL plugin](https://github.com/vitejs/vite-plugin-basic-ssl)
 ::
 
+## Field Access Checks
+
+When used with Directus 11.16.0+, the library validates field-level permissions before activating editable elements. After `apply()` is called, elements go through a two-phase lifecycle:
+
+1. **Construction** — elements are registered based on `data-directus` attributes
+2. **Activation** — Directus verifies the current user's permissions and only activates elements for fields the user can edit
+
+Elements that fail the permission check remain inert — no overlay, hover listeners, or click handlers are attached.
+
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Minimum Version Requirement**
+Field access checks require `@directus/visual-editing` v2.0.0+ and Directus 11.16.0+. Without a compatible Directus instance responding to the permission check, elements will not display edit overlays.
+::
+
 ## Usage in Non-JS Environments
 
 Given this library is built as a Node package, environments that can’t take advantage of NPM will need to take a slightly different approach to including the functionality in their websites.

--- a/content/guides/02.content/8.visual-editor/2.studio-module.md
+++ b/content/guides/02.content/8.visual-editor/2.studio-module.md
@@ -9,11 +9,30 @@ The visual editor module enables content editors to render their website within 
 
 ## Configure Visual Editor URLs
 
-Navigate to Settings -> Visual Editor and add the URL of your website that you want to visually edit within the visual editor module. If you have multiple websites that you wish to edit, then add multiple URLs.
+Navigate to **Settings → Visual Editor** and add the URL of your website that you want to visually edit. If you have multiple websites, add multiple URLs.
 
 ![An image of the visual editor section of the Directus settings page with one URL entered](/img/visual_editor_settings_url.png)
 
 Be sure to enable the Visual Editor from the Modules section of the settings page so it shows up in your project's module bar.
+
+### Version Support in URLs
+
+The URL field supports a `{{$version}}` template variable. When included, the Visual Editor will pass the currently selected version key to your website, enabling version-aware previews.
+
+```
+https://your-site.com/preview?version={{$version}}
+```
+
+When no version is selected, `{{$version}}` resolves to `main`. The variable can be placed in any part of the URL — query parameters, path segments, subdomains, or hash fragments.
+
+::callout{icon="material-symbols:info-outline"}
+If `{{$version}}` is not included in any URL, version selection will not be available in the toolbar.
+::
+
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Website Implementation Required**
+Adding `{{$version}}` to the URL passes the version key to your website and ensures that edits made in the Visual Editor are saved to the selected version instead of the main item. However, your website must also read this parameter and fetch versioned content using the `version` query parameter on the [items endpoint](/api/items) (e.g. `/items/posts/42?version=draft`). Without this, the website will display main content regardless of the selected version.
+::
 
 ::callout{icon="material-symbols:info"}
 **Configure Your Website**
@@ -55,3 +74,38 @@ Clicking the :icon{name="material-symbols:edit"} beside an editable element will
 ![An image of the visual editor with the drawer open on a page and an input being edited in a popover](/img/visual_editor_open_popover.png)
 
 Once you are done editing your item, click the save button and your website will refresh to show your changes.
+
+## Working with Versions
+
+When a URL includes the `{{$version}}` variable, a version dropdown appears in the toolbar.
+
+### Selecting a Version
+
+The dropdown lists:
+
+- **Main** — the published version (default)
+- **Draft** — the global [draft version](/guides/content/content-versioning#working-with-the-draft-version), always available for collections with versioning enabled
+
+If your website URL contains a version key that doesn't match "main" or "draft" (e.g. from a custom query parameter), it will also appear as a dynamic option in the dropdown.
+
+### Version-Aware Editing
+
+When a version other than main is selected:
+
+- **Only items on collections with versioning enabled** will show editable elements. Items on non-versioned collections are hidden from editing.
+- **Saving an edit** creates or updates the version for that specific item. If the version doesn't exist yet for the item, it's created automatically on save.
+- **Items without content in the selected version** display their main version content as a read-only fallback.
+
+::callout{icon="material-symbols:info-outline"}
+The version dropdown requires the user to have **read** permission on `directus_versions`. Editing in a version additionally requires **create** or **update** permission on `directus_versions`.
+::
+
+## Permissions
+
+Editable elements are gated by field-level permissions. When visual editing is active, Directus validates each element against the current user's access before making it interactive:
+
+- **Admin users** can edit all elements.
+- **Non-admin users** only see editable overlays on fields they have **update** permission for.
+- When a **version is selected**, elements are additionally hidden for collections that don't have versioning enabled, and for users without the required `directus_versions` permissions.
+
+Elements that fail permission checks remain completely inert — no overlay, no hover effect, no click handler.

--- a/content/guides/02.content/8.visual-editor/2.studio-module.md
+++ b/content/guides/02.content/8.visual-editor/2.studio-module.md
@@ -26,7 +26,7 @@ https://your-site.com/preview?version={{$version}}
 When no version is selected, `{{$version}}` resolves to `main`. The variable can be placed in any part of the URL — query parameters, path segments, subdomains, or hash fragments.
 
 ::callout{icon="material-symbols:info-outline"}
-If `{{$version}}` is not included in any URL, version selection will not be available in the toolbar.
+If `{{$version}}` is not included in any URL, version selection will not be available in the toolbar of the Visual Editor.
 ::
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}

--- a/content/guides/02.content/8.visual-editor/2.studio-module.md
+++ b/content/guides/02.content/8.visual-editor/2.studio-module.md
@@ -23,32 +23,31 @@ The URL field supports a `{{$version}}` template variable. When included, the Vi
 https://your-site.com/preview?version={{$version}}
 ```
 
-When no version is selected, `{{$version}}` resolves to `main`. The variable can be placed in any part of the URL — query parameters, path segments, subdomains, or hash fragments.
+ - **Resolution**: When no version is selected, `{{$version}}` resolves to `main`. 
+ - **Flexibility**: The variable can be placed in any part of the URL (query parameters, path segments, subdomains, or hash fragments).
 
-::callout{icon="material-symbols:info-outline"}
-If `{{$version}}` is not included in any URL, version selection will not be available in the toolbar of the Visual Editor.
-::
+ #### Implementation Checklist
+
+ To ensure version-aware editing functions correctly, verify the following configuration steps:
+
+ **1. Frontend Integration**
+  - **Template Variable**: You must include `{{$version}}` in the URL field. If omitted, the version selection dropdown will not appear in the Visual Editor toolbar.
+  - **Directus Frontend Library**: Your website must be configured using our publicly available [Frontend Library](1.frontend-library.md).
+  - **Version-Aware Fetching**: Your code must detect the version parameter from the URL and pass it to the Directus API (e.g., `/items/posts/42?version=draft`). Without this, the site will continue to display "Main" content regardless of your selection.
+
+  **2. Environment Configuration**
+
+  Update your Directus instance environment variables to authorize the connection and ensure content refreshes:
+
+  | Variable | Required Value | Purpose |
+| :--- | :--- | :--- |
+| `CONTENT_SECURITY_POLICY_DIRECTIVES__FRAME_SRC` | `"<your-website-url>"` | Allows your website to be embedded within the Directus Studio iframe. |
+| `CACHE_AUTO_PURGE` | `true` | Ensures the preview reflects changes immediately after saving edits. |
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
-**Website Implementation Required**
-Adding `{{$version}}` to the URL passes the version key to your website and ensures that edits made in the Visual Editor are saved to the selected version instead of the main item. However, your website must also read this parameter and fetch versioned content using the `version` query parameter on the [items endpoint](/api/items) (e.g. `/items/posts/42?version=draft`). Without this, the website will display main content regardless of the selected version.
-::
-
-::callout{icon="material-symbols:info"}
-**Configure Your Website**
-In order to work with Directus, your website’s frontend must first be configured using our publicly available [Frontend Library](/guides/content/visual-editor/frontend-library).
-::
-
-::callout{icon="material-symbols:warning-rounded" color="warning"}
-**Configure Content Security Policy**
-Your website will not be able to speak to your Directus instance if you do not set `CONTENT_SECURITY_POLICY_DIRECTIVES__FRAME_SRC="<your-website-base-url>"` within your instances env.<br>
-[Learn more about Directus env security settings](/configuration/security-limits)
-::
-
-::callout{icon="material-symbols:warning-rounded" color="warning"}
-**Configure Cache Auto Purge**
-Be sure to set `CACHE_AUTO_PURGE=true` in your Directus instances’s env.<br>
-[Learn more about Directus env cache settings](/configuration/cache)
+**Critical Setup**: Your website will be unable to communicate with Directus if the `CONTENT_SECURITY_POLICY_DIRECTIVES__FRAME_SRC` directive is missing.  
+<br>
+Additionally, without `CACHE_AUTO_PURGE` enabled, the Visual Editor will continue to display stale data until the cache naturally expires.
 ::
 
 ## Editing in the Module

--- a/content/guides/02.content/8.visual-editor/2.studio-module.md
+++ b/content/guides/02.content/8.visual-editor/2.studio-module.md
@@ -77,7 +77,7 @@ Once you are done editing your item, click the save button and your website will
 
 ## Working with Versions
 
-When a URL includes the `{{$version}}` variable, a version dropdown appears in the toolbar.
+When a URL includes the `{{$version}}` variable, a version dropdown appears in the toolbar of the Visual Editor.
 
 ### Selecting a Version
 


### PR DESCRIPTION
## Summary

- **Studio Module**: Document `{{$version}}` URL template variable, version dropdown behavior, version-aware editing, and field-level permission checks
- **Frontend Library**: Document two-phase element lifecycle and field access checks (requires `@directus/visual-editing` v2.0.0+ / Directus 11.16.0+)
- **Live Preview**: Add version support notes for visual editing in live preview
- **Content Versioning**: Fix incorrect `{{version}}` → `{{$version}}` in VE URL example, clarify website implementation requirement

All pages now consistently explain that `{{$version}}` both controls where edits are saved *and* passes the version key to the website, and that the website must separately implement version-aware content fetching via the items endpoint `?version=` parameter.

Related PRs:
- directus/directus#26772 (main feature branch)
- directus/directus#26507 (global draft version)
- directus/directus#26720 (VE version support)
- directus/directus#26749 (field permissions + version access checks)
- directus/directus#26760 (version support in live preview)
- directus/visual-editing#34 (field access checks in library)