### PR TITLE
Fix statement for regarding null accountability and schema definition

### DIFF
--- a/content/guides/09.extensions/2.api-extensions/4.services.md
+++ b/content/guides/09.extensions/2.api-extensions/4.services.md
@@ -8,10 +8,10 @@ API extensions can directly use internal Directus services like the `ItemsServic
 
 When initializing services, you will need the following:
 
-| Parameter | Description |
-| --- | --- |
-| `schema` | [Knex](https://knexjs.org/) database schema, provided by the `getSchema` function. |
-| `accountability` | Accountability object, used for access control. Omission will use administrator permissions. `null` will use public permissions. |
+| Parameter        | Description                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `schema`         | [Knex](https://knexjs.org/) database schema, provided by the `getSchema` function.                     |
+| `accountability` | Accountability object, used for access control. Omission or `null` will use administrator permissions. |
 
 
 ::callout{icon="material-symbols:link" to="https://github.com/directus/directus/tree/main/api/src/services"}

--- a/content/guides/09.extensions/2.api-extensions/4.services.md
+++ b/content/guides/09.extensions/2.api-extensions/4.services.md
@@ -10,7 +10,7 @@ When initializing services, you will need the following:
 
 | Parameter        | Description                                                                                            |
 | ---------------- | ------------------------------------------------------------------------------------------------------ |
-| `schema`         | [Knex](https://knexjs.org/) database schema, provided by the `getSchema` function.                     |
+| `schema`         | The database schema, provided by the `getSchema` function.                     |
 | `accountability` | Accountability object, used for access control. Omission or `null` will use administrator permissions. |
 
 


### PR DESCRIPTION
Fixes an incorrect statements about:
- `null` accountability indicating public permissions
- `schema` being based on `knex` schema