### PR TITLE
Callout `storage` parameter is now optional in uploads

### DIFF
--- a/content/guides/05.files/1.upload.md
+++ b/content/guides/05.files/1.upload.md
@@ -26,7 +26,6 @@ Optionally, you can also click the file display to open the file details page an
 ## API
 
 ::code-group
-
 ```http [REST]
 // POST /files
 

--- a/content/guides/05.files/1.upload.md
+++ b/content/guides/05.files/1.upload.md
@@ -55,7 +55,6 @@ const result = await directus.request(uploadFiles(formData));
 The file contents has to be provided in a property called `file`. All other properties of
 the file object can be provided as well, except `filename_disk` and `filename_download`.
 
-
 ::callout{icon="material-symbols:info" color="info"}
 If `storage` is not specified, it defaults to the first location listed in [`STORAGE_LOCATIONS`](/configuration/files#storage-locations).
 ::

--- a/content/guides/05.files/1.upload.md
+++ b/content/guides/05.files/1.upload.md
@@ -38,16 +38,15 @@ Body must be formatted as a `multipart/form-data` with a final property called `
 ```
 
 ```js [SDK]
-import { createDirectus, rest, uploadFiles } from "@directus/sdk";
+import { createDirectus, rest, uploadFiles } from '@directus/sdk';
 
-const directus = createDirectus("https://directus.example.com").with(rest());
+const directus = createDirectus('https://directus.example.com').with(rest());
 
 const formData = new FormData();
-formData.append("storage", "s3"); // optional, defaults to first STORAGE_LOCATIONS
-formData.append("file_1_property", "Value");
-formData.append("file", raw_file);
-formData.append("file_2_property", "Value");
-formData.append("file", raw_file_2);
+formData.append('file_1_property', 'Value');
+formData.append('file', raw_file);
+formData.append('file_2_property', 'Value');
+formData.append('file', raw_file_2);
 
 const result = await directus.request(uploadFiles(formData));
 ```

--- a/content/guides/05.files/1.upload.md
+++ b/content/guides/05.files/1.upload.md
@@ -26,6 +26,7 @@ Optionally, you can also click the file display to open the file details page an
 ## API
 
 ::code-group
+
 ```http [REST]
 // POST /files
 
@@ -37,15 +38,16 @@ Body must be formatted as a `multipart/form-data` with a final property called `
 ```
 
 ```js [SDK]
-import { createDirectus, rest, uploadFiles } from '@directus/sdk';
+import { createDirectus, rest, uploadFiles } from "@directus/sdk";
 
-const directus = createDirectus('https://directus.example.com').with(rest());
+const directus = createDirectus("https://directus.example.com").with(rest());
 
 const formData = new FormData();
-formData.append('file_1_property', 'Value');
-formData.append('file', raw_file);
-formData.append('file_2_property', 'Value');
-formData.append('file', raw_file_2);
+formData.append("storage", "s3"); // optional, defaults to first STORAGE_LOCATIONS
+formData.append("file_1_property", "Value");
+formData.append("file", raw_file);
+formData.append("file_2_property", "Value");
+formData.append("file", raw_file_2);
 
 const result = await directus.request(uploadFiles(formData));
 ```
@@ -54,3 +56,6 @@ const result = await directus.request(uploadFiles(formData));
 
 The file contents has to be provided in a property called `file`. All other properties of
 the file object can be provided as well, except `filename_disk` and `filename_download`.
+
+You can optionally provide a `storage` property to specify which storage location to use. If omitted, it defaults to
+the first location configured in the `STORAGE_LOCATIONS` environment variable.

--- a/content/guides/05.files/1.upload.md
+++ b/content/guides/05.files/1.upload.md
@@ -57,5 +57,7 @@ const result = await directus.request(uploadFiles(formData));
 The file contents has to be provided in a property called `file`. All other properties of
 the file object can be provided as well, except `filename_disk` and `filename_download`.
 
-You can optionally provide a `storage` property to specify which storage location to use. If omitted, it defaults to
-the first location configured in the `STORAGE_LOCATIONS` environment variable.
+
+::callout{icon="material-symbols:info" color="info"}
+If `storage` is not specified, it defaults to the first location listed in [`STORAGE_LOCATIONS`](/configuration/files#storage-locations).
+::


### PR DESCRIPTION
Following https://github.com/directus/directus/compare/cms-1425 implementation