### PR TITLE
Fix build error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,5 @@
 shamefully-hoist=true
+public-hoist-pattern[]=@img/*
+public-hoist-pattern[]=@resvg/*
+public-hoist-pattern[]=@oxc-parser
+public-hoist-pattern[]=@parcel/watcher*

--- a/content/guides/02.content/4.import-export.md
+++ b/content/guides/02.content/4.import-export.md
@@ -27,7 +27,7 @@ permissions for the related collection.
 
 ::callout{icon="material-symbols:info-outline"}
 **Import Error Handling**
-During import operations, errors are collected up to the maximum defined by [`MAX_IMPORT_ERRORS`](/content/configuration/security-limits.md), after which the import is cancelled.
+During import operations, errors are collected up to the maximum defined by [`MAX_IMPORT_ERRORS`](/configuration/security-limits), after which the import is cancelled.
 ::
 
 ## Export Items
@@ -44,14 +44,14 @@ To export items, follow the steps below, navigate to the desired collection and 
 This menu provides granular control over exactly which items and fields are exported, how they are exported, and where
 they are exported.
 
-| Item | Description |
-|---|---|
-| **Format** | Choose to export items as CSV, JSON, XML, or YAML. |
-| **Limit** | Set the maximum number of items to be exported. |
-| **Export Location** | Download the export file directly to your machine or to the file library. |
-| **Folder** | Choose the Folder to download to (if export location is the folder library). |
-| **Sort Field** | Choose field to sort items by. |
-| **Sort Direction** | Choose to sort items in ascending or descending order. |
-| **Full-Text Search** | Limit exported Items to ones which matched as search results. |
-| **Filter** | Limit exported items with a filter. |
-| **Fields** | Add, remove, and re-order the item fields that will be exported.  |
+| Item                 | Description                                                                  |
+| -------------------- | ---------------------------------------------------------------------------- |
+| **Format**           | Choose to export items as CSV, JSON, XML, or YAML.                           |
+| **Limit**            | Set the maximum number of items to be exported.                              |
+| **Export Location**  | Download the export file directly to your machine or to the file library.    |
+| **Folder**           | Choose the Folder to download to (if export location is the folder library). |
+| **Sort Field**       | Choose field to sort items by.                                               |
+| **Sort Direction**   | Choose to sort items in ascending or descending order.                       |
+| **Full-Text Search** | Limit exported Items to ones which matched as search results.                |
+| **Filter**           | Limit exported items with a filter.                                          |
+| **Fields**           | Add, remove, and re-order the item fields that will be exported.             |

--- a/package.json
+++ b/package.json
@@ -41,12 +41,18 @@
 		"vue-tsc": "^3.2.4"
 	},
 	"pnpm": {
+		"supportedArchitectures": {
+			"os": ["current", "linux"],
+			"cpu": ["current", "x64"],
+			"libc": ["current", "musl"]
+		},
 		"overrides": {
 			"reka": "2.3.1",
 			"debug": "4.4.1"
 		},
 		"onlyBuiltDependencies": [
-			"better-sqlite3"
+			"better-sqlite3",
+			"sharp"
 		]
 	},
 	"packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"


### PR DESCRIPTION
In addition to Claude's fixes, this PR also corrects an incorrect link on the `import-export.md` file which was throwing a minor error

Fix summary from Claude

<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root causes identified</h3>
Error | Cause
-- | --
ENOENT: @resvg/resvg-js-linux-x64-musl | pnpm installed on macOS → only fetched darwin binaries; Vercel (Alpine/musl) had nothing to load
Cannot find native binding for @oxc-parser | Same - linux-x64-musl binding package was never resolved in the lockfile
@parcel/watcher-linux-x64-musl missing | Same root cause
sharp silently broken | onlyBuiltDependencies only listed better-sqlite3; pnpm 10 treats this as an allowlist, so sharp's postinstall never ran

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fixes applied</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><a href="vscode-webview://0nm8hbgravb3a8p8docualgjve9jp6hifg6tg23qqdp0vqn27e72/package.json" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">package.json</a></strong> - Two changes to the <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pnpm</code> config block:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Added<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">supportedArchitectures</code><span> </span>with<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">linux</code>/<code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">musl</code><span> </span>alongside<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">current</code><span> </span>- this tells pnpm to also resolve and download linux-x64-musl optional packages even when installing on macOS</li><li>Added<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sharp</code><span> </span>to<span> </span><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">onlyBuiltDependencies</code><span> </span>so its postinstall (which activates the prebuilt binary) is allowed to run</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><a href="vscode-webview://0nm8hbgravb3a8p8docualgjve9jp6hifg6tg23qqdp0vqn27e72/.npmrc" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">.npmrc</a></strong> - Added explicit <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">public-hoist-pattern[]</code> entries for native binary package scopes (<code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@img/*</code>, <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@resvg/*</code>, <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@oxc-parser</code>, <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@parcel/watcher*</code>) alongside <code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">shamefully-hoist</code>. This gives pnpm explicit guidance on hoisting these packages, avoiding the EEXIST collision that occurred when it tried to hoist conflicting platform-specific packages.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pnpm-lock.yaml</code></strong> - Regenerated. The lockfile now contains 27 linux-x64-musl entries including:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@resvg/resvg-js-linux-x64-musl@2.6.2</code></li><li><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@oxc-parser/binding-linux-x64-musl@0.112.0</code></li><li><code style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@parcel/watcher-linux-x64-musl@2.5.6</code></li><li>Plus arm/musl variants</li></ul>Summary
Root causes identified
Error	Cause
ENOENT: @resvg/resvg-js-linux-x64-musl	pnpm installed on macOS → only fetched darwin binaries; Vercel (Alpine/musl) had nothing to load
Cannot find native binding for @oxc-parser	Same - linux-x64-musl binding package was never resolved in the lockfile
@parcel/watcher-linux-x64-musl missing	Same root cause
sharp silently broken	onlyBuiltDependencies only listed better-sqlite3; pnpm 10 treats this as an allowlist, so sharp's postinstall never ran
Fixes applied
[package.json](vscode-webview://0nm8hbgravb3a8p8docualgjve9jp6hifg6tg23qqdp0vqn27e72/package.json) - Two changes to the pnpm config block:

Added supportedArchitectures with linux/musl alongside current - this tells pnpm to also resolve and download linux-x64-musl optional packages even when installing on macOS
Added sharp to onlyBuiltDependencies so its postinstall (which activates the prebuilt binary) is allowed to run
[.npmrc](vscode-webview://0nm8hbgravb3a8p8docualgjve9jp6hifg6tg23qqdp0vqn27e72/.npmrc) - Added explicit public-hoist-pattern[] entries for native binary package scopes (@img/*, @resvg/*, @oxc-parser, @parcel/watcher*) alongside shamefully-hoist. This gives pnpm explicit guidance on hoisting these packages, avoiding the EEXIST collision that occurred when it tried to hoist conflicting platform-specific packages.

pnpm-lock.yaml - Regenerated. The lockfile now contains 27 linux-x64-musl entries including:

@resvg/resvg-js-linux-x64-musl@2.6.2
@oxc-parser/binding-linux-x64-musl@0.112.0
@parcel/watcher-linux-x64-musl@2.5.6
Plus arm/musl variants