### PR TITLE
Update content versioning terminology from 'main' to 'published'

### DIFF
--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -10,11 +10,11 @@ use content versioning, including drafting content without publishing it, and mo
 
 ## Concepts
 
-- **Version**: A version of an item that allows you to safely make changes without affecting the main item. Versions can be promoted to become the new main item.
-- **Main**: The published version of your content that is live and visible to users. All new versions are created from the main item.
-- **Draft**: a reserved global version that is automatically available when content versioning is enabled. The draft version provides a dedicated workspace for making changes before publishing to main, and appears empty until edits are saved.
-- **Promote**: when a version is promoted, it becomes the main item that is displayed to users.
-- **Revision**: revisions are individual changes to items made within a version or main item. Directus keeps track of all changes made, so you're able to view the history of modifications and revert to a previous state.
+- **Version**: A version of an item that allows you to safely make changes without affecting the published item. Versions can be promoted to become the new published item.
+- **Published**: The published version of your content that is live and visible to users. All new versions are created from the published item. This version is identified by the reserved key `published` (the key `main` also works and is kept for backward compatibility).
+- **Draft**: a reserved global version that is automatically available when content versioning is enabled. The draft version provides a dedicated workspace for making changes before publishing, and appears empty until edits are saved.
+- **Promote**: when a version is promoted, it becomes the published item that is displayed to users.
+- **Revision**: revisions are individual changes to items made within a version or the published item. Directus keeps track of all changes made, so you're able to view the history of modifications and revert to a previous state.
 
 ::callout{icon="material-symbols:info-outline" to="/guides/content/live-preview"}
 **Using Versions in Live Preview**  
@@ -41,6 +41,11 @@ The draft version:
 - Transforms from a virtual placeholder to an actual version when you save changes
 - Uses "**draft**" as a reserved version key that cannot be used for custom versions
 
+::callout{icon="material-symbols:info-outline"}
+**Reserved version keys**
+The keys `published`, `main`, and `draft` are all reserved and cannot be used for custom versions. Attempting to create a version with any of these keys returns a `400` error.
+::
+
 ::callout{icon="material-symbols:warning"}
 **Backward Compatibility**  
 The reserved global "draft" version was introduced in Directus 11.16.0. If you have an existing version with the key `draft` and a custom name other than "Draft", the display name will be standardized to "Draft" (i.e. transformed) to support the new global versioning feature. The version content and functionality remain unchanged.
@@ -50,21 +55,21 @@ The reserved global "draft" version was introduced in Directus 11.16.0. If you h
 
 The Visual Editor integrates seamlessly with the draft version, allowing you to preview and edit changes in context:
 
-1. **Switch versions** using the dropdown in the Visual Editor header to toggle between "Main" and "Draft"
+1. **Switch versions** using the dropdown in the Visual Editor header to toggle between "Published" and "Draft"
 2. **Edit items** that have content in the active version – items are only directly editable when they exist in the selected version
-3. **Preview changes** using the version-aware preview URL before publishing to main
-4. **Fallback behavior** - items without content in the selected version display their main version content (read-only)
+3. **Preview changes** using the version-aware preview URL before publishing
+4. **Fallback behavior** - items without content in the selected version display their published version content (read-only)
 
 
 ## Creating a New Version
 
 ![Creating a new version in the content module](/img/versions-example.png)
 
-Open an item within your versioned collection. At the top of the item view, you will notice a dropdown with the main Content Version displayed as "main". Select "Create Version" and provide a key and a name for the new version. You can then save your new version.
+Open an item within your versioned collection. At the top of the item view, you will notice a dropdown with the published content version displayed as "Published". Select "Create Version" and provide a key and a name for the new version. You can then save your new version.
 
 ::callout{icon="material-symbols:info-outline"}
 **Version Source**  
-All new versions originate from the main item. This implies that the main item acts as the single source of truth for other versions. The draft version is always available and doesn't need to be manually created.
+All new versions originate from the published item. This implies that the published item acts as the single source of truth for other versions. The draft version is always available and doesn't need to be manually created.
 ::
 
 ## Making Changes to a Version
@@ -80,19 +85,19 @@ Upon saving the changes, you'll notice that the main item remains unaffected, wh
 ![Promoting a version, comparing its changes](/img/versions-example-comparison.png)
 
 
-Promoting a version makes it the main (current) version of your content.
+Promoting a version makes it the published (current) version of your content.
 
 ### How to Promote a Version
 
 1. Open the version you want to promote
 2. Select the **"Promote Version"** option from the dropdown. 
 3. In the comparison modal, review the changes:
-   - Fields with differences from the main item are highlighted with color indicators
+   - Fields with differences from the published item are highlighted with color indicators
    - Review each highlighted field to understand what will change
 4. Accept or reject individual changes as needed
 5. Click **"Promote"** to finalize and make this version the new main item
 
-Once promoted, this version becomes the active content, and the previous main item is preserved in the version history. 
+Once promoted, this version becomes the active content, and the previous published item is preserved in the version history.
 
 After promoting a version, you can choose to keep or delete the version. For the global draft version, you'll see options to "Discard Edits" or "Keep Edits" instead of "Delete Version" or "Keep Version".
 
@@ -184,7 +189,7 @@ When working with content versioning through the API, it's important to understa
 
 ### Standard Item Response
 
-When fetching items from a collection endpoint `/items/{collection}`, you receive the main version data:
+When fetching items from a collection endpoint `/items/{collection}`, you receive the published version data:
 ```json
 {
   "data": [
@@ -223,4 +228,4 @@ When fetching versions from the `/versions/{version}` endpoint, each version con
 }
 ```
 
-The `delta` object contains only the modified fields, making it easy to see exactly what changed in each version compared to the state of main at the time that version was created.
+The `delta` object contains only the modified fields, making it easy to see exactly what changed in each version compared to the published item at the time that version was created.

--- a/content/guides/02.content/8.visual-editor/2.studio-module.md
+++ b/content/guides/02.content/8.visual-editor/2.studio-module.md
@@ -27,7 +27,7 @@ The URL field supports a `{{$version}}` template variable. When included, the Vi
 https://your-site.com/preview?version={{$version}}
 ```
 
- - **Resolution**: When no version is selected, `{{$version}}` resolves to `main`. 
+ - **Resolution**: When no version is selected, `{{$version}}` resolves to `published`.
  - **Flexibility**: The variable can be placed in any part of the URL (query parameters, path segments, subdomains, or hash fragments).
 
  #### Implementation Checklist
@@ -37,7 +37,7 @@ https://your-site.com/preview?version={{$version}}
  **1. Frontend Integration**
   - **Template Variable**: You must include `{{$version}}` in the URL field. If omitted, the version selection dropdown will not appear in the Visual Editor toolbar.
   - **Directus Frontend Library**: Your website must be configured using our publicly available [Frontend Library](1.frontend-library.md).
-  - **Version-Aware Fetching**: Your code must detect the version parameter from the URL and pass it to the Directus API (e.g., `/items/posts/42?version=draft`). Without this, the site will continue to display "Main" content regardless of your selection.
+  - **Version-Aware Fetching**: Your code must detect the version parameter from the URL and pass it to the Directus API (e.g., `/items/posts/42?version=draft`). Without this, the site will continue to display "Published" content regardless of your selection.
 
   **2. Environment Configuration**
 
@@ -86,18 +86,18 @@ When a URL includes the `{{$version}}` variable, a version dropdown appears in t
 
 The dropdown lists:
 
-- **Main** — the published version (default)
+- **Published** — the published version (default)
 - **Draft** — the global [draft version](/guides/content/content-versioning#working-with-the-draft-version), always available for collections with versioning enabled
 
-If your website URL contains a version key that doesn't match "main" or "draft" (e.g. from a custom query parameter), it will also appear as a dynamic option in the dropdown.
+If your website URL contains a version key that doesn't match "published", "main", or "draft" (e.g. from a custom query parameter), it will also appear as a dynamic option in the dropdown.
 
 ### Version-Aware Editing
 
-When a version other than main is selected:
+When a version other than "Published" is selected:
 
 - **Only items on collections with versioning enabled** will show editable elements. Items on non-versioned collections are hidden from editing.
 - **Saving an edit** creates or updates the version for that specific item. If the version doesn't exist yet for the item, it's created automatically on save.
-- **Items without content in the selected version** display their main version content as a read-only fallback.
+- **Items without content in the selected version** display their published version content as a read-only fallback.
 
 ::callout{icon="material-symbols:info-outline"}
 The version dropdown requires the user to have **read** permission on `directus_versions`. Editing in a version additionally requires **create** or **update** permission on `directus_versions`.

--- a/content/guides/04.connect/3.query-parameters.md
+++ b/content/guides/04.connect/3.query-parameters.md
@@ -537,6 +537,11 @@ Saves the API response to a file. Valid values are `csv`, `json`, `xml`, `yaml`.
 
 Queries a version of a record by version key when [content versioning](/guides/content/content-versioning) is enabled on a collection. Applies only to single item retrieval.
 
+::callout{icon="material-symbols:info-outline"}
+**Reserved version keys**
+The keys `published` and `draft` are reserved. Use `published` (or `main` for backward compatibility) to explicitly fetch the published base item. Use `draft` to fetch the global draft version.
+::
+
 ```http [GET /items/posts/1]
 ?version=v1
 ```

--- a/content/tutorials/1.getting-started/implementing-live-preview-in-astro.md
+++ b/content/tutorials/1.getting-started/implementing-live-preview-in-astro.md
@@ -282,7 +282,7 @@ Next, update the Directus live preview URL pattern to include the version. The U
 ## Testing Live Preview
 
 To test the live preview, navigate to the `http://localhost:4321/` page and click on any of the posts. You will be redirected to the post page, and the post content will be displayed.
-At the end of the URL, add `?preview=true&token=YOUR_GENERATED_TOKEN&version=main` to view the post in preview mode.
+At the end of the URL, add `?preview=true&token=YOUR_GENERATED_TOKEN&version=published` to view the post in preview mode.
 
 This should provide you with a preview of the post content that looks like the image below:
 


### PR DESCRIPTION
## Summary
- Replace references to "main" version with "published" throughout content versioning docs
- Add callout noting `published`, `main`, and `draft` are all reserved version keys (with `main` kept for backward compatibility)
- Update Visual Editor docs to reflect new `published` default in version dropdown
- Update query parameters docs with callout on reserved version keys (`published`, `draft`)
- Update Astro live preview tutorial to use `version=published` instead of `version=main`

Part of CMS-1819