### PR TITLE
docs: clarify required field validation in content versioning

### DIFF
--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -75,6 +75,11 @@ Open the item in the newly created version, and make the desired edits to the it
 
 Upon saving the changes, you'll notice that the main item remains unaffected, while the changes are reflected only in the modified version.
 
+::callout{icon="material-symbols:info-outline"}
+**Required Fields**
+Versions can be saved even if required fields are empty. Validation of required fields is deferred to promote time, so you can save partial drafts without completing all required fields.
+::
+
 ## Comparing and Promoting a Version
 
 ![Promoting a version, comparing its changes](/img/versions-example-comparison.png)
@@ -85,12 +90,12 @@ Promoting a version makes it the main (current) version of your content.
 ### How to Promote a Version
 
 1. Open the version you want to promote
-2. Select the **"Promote Version"** option from the dropdown. 
+2. Select the **"Promote Version"** option from the dropdown.
 3. In the comparison modal, review the changes:
    - Fields with differences from the main item are highlighted with color indicators
    - Review each highlighted field to understand what will change
 4. Accept or reject individual changes as needed
-5. Click **"Promote"** to finalize and make this version the new main item
+5. Click **"Promote"** to finalize and make this version the new main item. If any required fields are empty, validation errors are shown at this point - fill in the missing fields before promoting
 
 Once promoted, this version becomes the active content, and the previous main item is preserved in the version history. 
 


### PR DESCRIPTION
## Summary
- Adds callout in "Making Changes to a Version" noting versions can be saved with empty required fields - validation is deferred to promote time
- Updates "How to Promote a Version" steps to clarify that clicking Promote triggers validation and missing required fields must be filled before the promote completes

Relates to https://github.com/directus/directus/pull/26905