### PR TITLE
docs: add itemless draft creation flow to content versioning guide

### DIFF
--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -56,6 +56,27 @@ The Visual Editor integrates seamlessly with the draft version, allowing you to 
 4. **Fallback behavior** - items without content in the selected version display their main version content (read-only)
 
 
+## Creating New Items as Drafts
+
+In a versioned collection, clicking **"Create Item"** (the `+` button) automatically puts you into draft context. Instead of creating the item immediately, Directus opens the form in the draft version - no published item exists yet.
+
+### Saving an Itemless Draft
+
+Fill in your fields and save as normal. On first save, Directus creates a draft version with no published item backing it. The item does not yet exist in the collection.
+
+You can save as many times as needed. Required fields do not need to be complete at this stage - see [Making Changes to a Version](#making-changes-to-a-version).
+
+### Publishing via Promote
+
+When you are ready to publish, select **"Promote Version"** from the version dropdown. Because there is no existing item to compare against, Directus skips the comparison modal and creates the item directly.
+
+After promotion, you are redirected to the newly created item in its main version.
+
+::callout{icon="material-symbols:info-outline"}
+**Permissions**
+Promoting an itemless draft creates a new item, so it requires **create** permission on the collection - not edit permission.
+::
+
 ## Creating a New Version
 
 ![Creating a new version in the content module](/img/versions-example.png)

--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -75,6 +75,11 @@ Open the item in the newly created version, and make the desired edits to the it
 
 Upon saving the changes, you'll notice that the main item remains unaffected, while the changes are reflected only in the modified version.
 
+::callout{icon="material-symbols:info-outline"}
+**Required Fields**
+Versions can be saved even if required fields are empty. Validation of required fields is deferred to promote time, so you can save partial drafts without completing all required fields.
+::
+
 ## Comparing and Promoting a Version
 
 ![Promoting a version, comparing its changes](/img/versions-example-comparison.png)
@@ -85,12 +90,12 @@ Promoting a version makes it the main (current) version of your content.
 ### How to Promote a Version
 
 1. Open the version you want to promote
-2. Select the **"Promote Version"** option from the dropdown. 
+2. Select the **"Promote Version"** option from the dropdown.
 3. In the comparison modal, review the changes:
    - Fields with differences from the main item are highlighted with color indicators
    - Review each highlighted field to understand what will change
 4. Accept or reject individual changes as needed
-5. Click **"Promote"** to finalize and make this version the new main item
+5. Click **"Promote"** to finalize and make this version the new main item. If any required fields are empty, validation errors are shown at this point - fill in the missing fields before promoting
 
 Once promoted, this version becomes the active content, and the previous main item is preserved in the version history. 
 


### PR DESCRIPTION
## Summary

- Adds a new "Creating New Items as Drafts" section to the content versioning guide
- Explains that clicking `+` in a versioned collection auto-enters draft context (no item created yet)
- Covers saving itemless drafts and the promote-to-publish flow that skips the comparison modal
- Notes the create-permission requirement for promoting itemless drafts

## Related

Documents the user-facing behavior introduced by https://github.com/directus/directus/pull/26916 (CMS-1860).