### PR TITLE
Document Redis namespace and metrics prefix env vars

### DIFF
--- a/content/configuration/metrics.md
+++ b/content/configuration/metrics.md
@@ -5,12 +5,14 @@ description: Configuration for metrics.
 
 To enable performance and error measurement of connected services, Directus can provide Prometheus metrics.
 
-| Variable           | Description                                                                                                             | Default Value                  |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `METRICS_ENABLED`  | Whether or not to enable metrics.                                                                                       | `false`                        |
-| `METRICS_SCHEDULE` | The cron schedule at which to generate the metrics, the default is every minute                                         | `*/1 * * * *`                  |
-| `METRICS_TOKENS`   | A CSV of tokens to allow access to via a `Authorization: Metrics <token>` header. By default it is restricted to admins | --                             |
-| `METRICS_SERVICES` | A CSV of directus services to observe metrics for. Currently `database`, `cache`, `redis` and `storage` are supported   | `database,cache,redis,storage` |
+| Variable                      | Description                                                                                                             | Default Value                  |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `METRICS_ENABLED`             | Whether or not to enable metrics.                                                                                       | `false`                        |
+| `METRICS_SCHEDULE`            | The cron schedule at which to generate the metrics, the default is every minute                                         | `*/1 * * * *`                  |
+| `METRICS_TOKENS`              | A CSV of tokens to allow access to via a `Authorization: Metrics <token>` header. By default it is restricted to admins | --                             |
+| `METRICS_SERVICES`            | A CSV of directus services to observe metrics for. Currently `database`, `cache`, `redis` and `storage` are supported   | `database,cache,redis,storage` |
+| `METRICS_NAME_PREFIX`         | Prefix applied to all Prometheus metric names.                                                                          | `directus_`                    |
+| `METRICS_HEALTH_CHECK_PREFIX` | Prefix for health check keys used in cache, Redis, and storage checks.                                                  | `directus-metric-`             |
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
 **Metric Aggregation**

--- a/content/configuration/synchronization.md
+++ b/content/configuration/synchronization.md
@@ -24,3 +24,14 @@ Redis is a critical component for Directus in multi-container deployments. It en
 | `REDIS_PORT`     | Port of the Redis instance.                                                                                 |               |
 | `REDIS_USERNAME` | Username for the Redis instance.                                                                            |               |
 | `REDIS_PASSWORD` | Password for the Redis instance.                                                                            |               |
+
+### Redis Namespaces
+
+When running multiple Directus instances against a single Redis server, configure unique namespace values per instance to avoid key collisions.
+
+| Variable                      | Description                            | Default Value       |
+| ----------------------------- | -------------------------------------- | ------------------- |
+| `REDIS_BUS_NAMESPACE`         | Namespace for the pub/sub message bus. | `directus:bus`      |
+| `REDIS_LOCK_NAMESPACE`        | Namespace for distributed locks.       | `directus:lock`     |
+| `REDIS_COUNTERS_NAMESPACE`    | Namespace for telemetry counters.      | `directus:counters` |
+| `REDIS_PERMISSIONS_NAMESPACE` | Namespace for the permissions cache.   | `permissions`       |


### PR DESCRIPTION
## Summary
- Document `REDIS_BUS_NAMESPACE`, `REDIS_LOCK_NAMESPACE`, `REDIS_COUNTERS_NAMESPACE`, and `REDIS_PERMISSIONS_NAMESPACE` in the synchronization/Redis config page
- Document `METRICS_NAME_PREFIX` and `METRICS_HEALTH_CHECK_PREFIX` in the metrics config page

These env vars are introduced in https://github.com/directus/directus/pull/26943 and allow multi-tenant deployments sharing a single Redis instance to avoid key collisions. Defaults match the previously hardcoded values, so this is non-breaking.

## Files Changed
- `content/configuration/synchronization.md` — added Redis Namespaces subsection
- `content/configuration/metrics.md` — added two prefix env vars to table