### PR TITLE
docs: published view read-only and Edit button for versioned items

### DIFF
--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -27,6 +27,17 @@ The version field is a dynamic variable can be added to the live preview URL so 
 
 Navigate to **Settings** > **Data Model**, select the collection that you want to enable content versioning for, and scroll down to the content versioning section. Toggle "Enable Versions" and save your data model.
 
+## Editing Versioned Items
+
+When content versioning is enabled for a collection, the published view is **read-only**. Fields are disabled and no Save button is shown. This enforces a draft-first workflow — all edits go through a version before reaching the published item.
+
+To start editing, click the **Edit** button in the item header (or press `⌘E` on Mac / `Ctrl+E` on Windows). Directus automatically switches you to the draft version, where you can make and save changes freely.
+
+::callout{icon="material-symbols:info-outline"}
+**Why read-only?**
+Preventing direct edits to the published item ensures changes go through the versioning workflow. This keeps your published content stable and gives your team a review step before changes go live.
+::
+
 ## Working with the Draft Version
 
 When content versioning is enabled for a collection, a global draft version is automatically available for all items. This reserved version provides a safe workspace for preparing changes before publishing to your live content.
@@ -97,7 +108,7 @@ All new versions originate from the published item. This implies that the publis
 
 ![Editing a version](/img/versioning_update.png)
 
-Open the item in the newly created version, and make the desired edits to the item's content.
+Open the item and switch to the version you want to edit using the version dropdown. The published view is read-only — you must be in a version context (draft or any custom version) to make changes.
 
 Upon saving the changes, you'll notice that the main item remains unaffected, while the changes are reflected only in the modified version.
 


### PR DESCRIPTION
## Summary
- Add new "Editing Versioned Items" section explaining that the published view is read-only when content versioning is enabled
- Document the Edit button (`⌘E` / `Ctrl+E`) in the item header that switches context to the draft version
- Update "Making Changes to a Version" to clarify you must be in a version context (not published view) to edit

## Related
Reflects app changes from https://github.com/directus/directus/pull/27022 (CMS-1862)

## Test plan
- [ ] Verify "Editing Versioned Items" section renders correctly
- [ ] Confirm keyboard shortcut syntax is accurate for both Mac and Windows