### PR TITLE
Correct sample Sharp API transformation from negate to normalize

### DIFF
--- a/content/guides/05.files/5.transform.md
+++ b/content/guides/05.files/5.transform.md
@@ -76,7 +76,7 @@ When calling the REST API, datatypes like booleans need to be passed as strings.
 | ---------------------------------------- | -------------------------------------------------------------- |
 | `.rotate(90)`                            | `[["rotate", 90]]`                                             |
 | `.rotate(90).blur(10).tint(255, 0, 255)` | `[["rotate", 90], ["blur", 10], ["tint", "rgb(255, 0, 255)"]]` |
-| `normalize({lower: 10, upper: 50})`         | `[["normalize", {"lower": 10, "upper": 50}]]`                     |
+| `normalize({lower: 10, upper: 50})`      | `[["normalize", {"lower": 10, "upper": 50}]]`                  |
 
 ::code-group
 ```http [REST]

--- a/content/guides/05.files/5.transform.md
+++ b/content/guides/05.files/5.transform.md
@@ -76,12 +76,12 @@ When calling the REST API, datatypes like booleans need to be passed as strings.
 | ---------------------------------------- | -------------------------------------------------------------- |
 | `.rotate(90)`                            | `[["rotate", 90]]`                                             |
 | `.rotate(90).blur(10).tint(255, 0, 255)` | `[["rotate", 90], ["blur", 10], ["tint", "rgb(255, 0, 255)"]]` |
-| `negate({lower: 10, upper: 50})`         | `[["negate", {"lower": 10, "upper": 50}]]`                     |
+| `normalize({lower: 10, upper: 50})`         | `[["normalize", {"lower": 10, "upper": 50}]]`                     |
 
 ::code-group
 ```http [REST]
 GET /assets/c984b755-e201-497e-b0a7-24156ad9c7e0
-	?transforms=[["rotate", 90],["blur", 10],["tint", "rgb(255, 0, 255)"], ["negate", {"lower": 10, "upper": 50}]]
+	?transforms=[["rotate", 90],["blur", 10],["tint", "rgb(255, 0, 255)"], ["normalize", {"lower": 10, "upper": 50}]]
 ```
 
 ```graphql [GraphQL]
@@ -102,7 +102,7 @@ const result = await directus.request(
       ['blur', 10],
       ['tint', 'rgb(255, 0, 255)'],
       [
-        'negate',
+        'normalize',
         {
           lower: 10,
           upper: 50,


### PR DESCRIPTION
The documentation displayed incorrect options for 'negate' but the options that were supplied match the 'normalize' function. Updated the function name to match the options.

See Sharp docs https://sharp.pixelplumbing.com/api-operation/#negate