### PR TITLE
docs: add collection-level draft browsing for versioned collections

### DIFF
--- a/content/guides/02.content/1.explore.md
+++ b/content/guides/02.content/1.explore.md
@@ -40,6 +40,26 @@ The following dynamic variables are built into Directus to add extra functionali
 
 :video-embed{video-id="a0f37f8b-c789-4421-b6c4-e4f681028d66"}
 
+## Browsing Draft Versions
+
+When [content versioning](/guides/content/content-versioning) is enabled for a collection, a **Published/Draft** selector appears in the collection page header. Use it to switch between viewing published items and their draft versions.
+
+### Draft Mode Behavior
+
+In draft mode, the collection page shows items that have pending draft changes, including [itemless drafts](/guides/content/content-versioning#creating-new-items-as-drafts) that have not yet been published. Click on any item to open it directly in its draft version.
+
+The following actions are **disabled** while in draft mode:
+
+- Batch editing
+- Archiving items
+- Exporting items
+- Manual sorting
+- Running Flows from the sidebar
+
+### Batch Deleting Drafts
+
+Selecting multiple items in draft mode and deleting them removes the **draft versions only** - the published items remain untouched. This is useful for discarding draft changes in bulk without affecting live content.
+
 ## Layouts
 
 Layouts are customized mechanisms for viewing and interacting with the items in a collection. You can [select a layout](/guides/content/layouts) for displaying your collection. Note that restrictions will apply depending on your collection's [data model](/guides/data-model/collections).

--- a/content/guides/02.content/6.content-versioning.md
+++ b/content/guides/02.content/6.content-versioning.md
@@ -33,6 +33,10 @@ When content versioning is enabled for a collection, a global draft version is a
 
 ![Content versioning draft](/img/versioning-draft.png)
 
+### Browsing Drafts from the Collection Page
+
+The [collection explorer](/guides/content/explore#browsing-draft-versions) includes a **Published/Draft** selector in the page header for versioned collections. Switch to draft mode to browse all items with pending draft changes across every layout (tabular, cards, calendar, kanban, and map). Some bulk actions like batch editing, archiving, and exporting are disabled in draft mode.
+
 ### Understanding the Draft Version
 
 The draft version:


### PR DESCRIPTION
## Summary
- Add "Browsing Draft Versions" section to Collection Explorer guide covering the Published/Draft selector, disabled actions in draft mode, and batch draft deletion
- Add cross-link from Content Versioning guide to the new collection-level draft browsing section

Documents the UI changes from directus/directus#27088 (version select + draft display on collection page).

## Test plan
- [ ] Verify new section renders correctly on dev server
- [ ] Confirm cross-links between explore and content-versioning pages resolve

Closes CMS-1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)