### PR TITLE
docs: add _ieq and _nieq filter operators

### DIFF
--- a/content/guides/04.connect/2.filter-rules.md
+++ b/content/guides/04.connect/2.filter-rules.md
@@ -11,6 +11,8 @@ Filters are used in permissions, validations, and automations, as well as throug
 | ---------------------------------- | --------------------------------------- |
 | `_eq` <sup>[1]</sup>               | Equals                                  |
 | `_neq` <sup>[1]</sup>              | Doesn't equal                           |
+| `_ieq`                             | Equals (case-insensitive)               |
+| `_nieq`                            | Doesn't equal (case-insensitive)        |
 | `_lt`                              | Less than                               |
 | `_lte`                             | Less than or equal to                   |
 | `_gt`                              | Greater than                            |


### PR DESCRIPTION
Closes directus/directus#18496.

Directus's filter engine has had `_ieq` (case-insensitive equal) and `_nieq` (case-insensitive not equal) for a while, but the filter-rules page doesn't list them, so users either don't know they exist or try to work around with `_icontains` on exact matches. They're the natural siblings to the `_icontains` / `_istarts_with` / `_iends_with` row that is documented -- same lower-cased comparison, just for equality instead of substring match.

I verified the SQL in `api/src/database/run-ast/lib/apply-query/filter/operator.ts`: `_ieq` is `LOWER(??) = LOWER(value)` and `_nieq` is `LOWER(??) <> LOWER(value)`. Added both to the operator table so they stand with their case-sensitive pair (`_eq` / `_neq`) and the other case-insensitive ops.