### PR TITLE
Remove beta from Zapier

### DIFF
--- a/app/components/IntegrationsList.vue
+++ b/app/components/IntegrationsList.vue
@@ -69,18 +69,8 @@ const integrations = [
 					</div>
 
 					<div class="p-3">
-						<!-- TODO: Remove Beta badge when Zapier integration is out of beta -->
-						<div class="text-gray-900 dark:text-white text-base font-bold text-pretty flex items-center gap-2">
+						<div class="text-gray-900 dark:text-white text-base font-bold text-pretty">
 							<span class="truncate">{{ integration.title }}</span>
-							<UBadge
-								v-if="integration.title === 'Zapier'"
-								variant="soft"
-								color="info"
-								size="sm"
-								class="shrink-0"
-							>
-								Beta
-							</UBadge>
 						</div>
 						<ProseP class="text-[15px] text-gray-500 dark:text-gray-400 mt-1 leading-snug">
 							{{ integration.description }}


### PR DESCRIPTION
Zapier is out of the required beta phase so remove the Beta tag 