### PR TITLE
Add AI policy note to CoC

### DIFF
--- a/content/community/1.overview/2.conduct.md
+++ b/content/community/1.overview/2.conduct.md
@@ -47,3 +47,8 @@ Project maintainers who do not follow or enforce the code of conduct in good fai
 This code of conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at [contributor-covenant.org](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 
 For answers to common questions about this code of conduct, see [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)
+
+## AI Usage
+
+For guidelines on the use of AI tools when contributing to this project, please review our
+[AI Usage Policy](https://github.com/directus/directus/blob/main/ai_policy.md).


### PR DESCRIPTION
Add note about AI policy added in https://github.com/directus/directus/pull/27146, to be merged after it.