### PR TITLE
docs(email): call out IAM permissions required for the SES transport

### DIFF
--- a/content/configuration/email.md
+++ b/content/configuration/email.md
@@ -50,6 +50,14 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide additional variables.
 | `EMAIL_SES_CREDENTIALS__SECRET_ACCESS_KEY` | Your AWS SES secret key.    |               |
 | `EMAIL_SES_REGION`                         | Your AWS SES region.        |               |
 
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**IAM permissions for SES**
+
+When `EMAIL_VERIFY_SETUP` is `true` (the default), Directus probes SES at startup and on every `/server/health` request, so a least-privilege IAM policy needs more than `ses:SendRawEmail`. If the policy is too narrow, the health endpoint responds with `Converting circular structure to JSON` rather than a clear permissions error, because the nested AWS SDK response object leaks into the JSON serializer.
+
+Community-reported minimum actions and resources are documented in [directus/docs#618](https://github.com/directus/docs/issues/618); start from that policy if you need to scope SES access narrowly. If you're willing to skip the probe, setting `EMAIL_VERIFY_SETUP=false` avoids the extra IAM calls altogether.
+::
+
 ## Email Templates
 
 Templates can be used to add custom templates for your emails, or to override the system emails used for things like resetting a password or inviting a user.


### PR DESCRIPTION
Fixes #618.

Running Directus with `EMAIL_TRANSPORT=ses` and a narrowly scoped IAM policy ends up hitting a weird symptom: password resets deliver fine, but `/server/health` answers with `Converting circular structure to JSON` instead of a normal permissions error. It happens because the SES nodemailer transport also probes the account on startup when `EMAIL_VERIFY_SETUP` is true (the default), and a policy that only grants `ses:SendRawEmail` fails that probe with a native AWS SDK error whose nested response object chokes `JSON.stringify`.

This PR just adds a warning callout under the AWS SES section of `content/configuration/email.md` so the next person doesn't spend an afternoon debugging serializer output. It names the exact error string, points at the community-verified policy on the linked issue as the starting point (rather than me claiming a minimum set of `ses:*` actions that are SDK/nodemailer version sensitive), and mentions `EMAIL_VERIFY_SETUP=false` as an opt-out for deployments that don't need the probe.

- [x] Documentation Update
- [x] I have read the contribution guidelines.