### PR TITLE
docs(files): document CORS_EXPOSED_HEADERS for TUS Directus-File-Id response header

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -137,6 +137,26 @@ the storage driver(s) being used.
 
 ::
 
+::callout{icon="material-symbols:info-outline"}
+
+**Reading `Directus-File-Id` from browsers across origins**<br/>
+
+When a chunked upload finishes, Directus returns the resulting file id in a custom response header, `Directus-File-Id`, rather than in the response body. Browsers strip non-safelisted response headers unless the server opts them in with `Access-Control-Expose-Headers`, so if the Data Studio or your app is hosted on a different origin than the API, `Directus-File-Id` is not set by default and you need to add it to [`CORS_EXPOSED_HEADERS`](/configuration/security-limits#cors):
+
+```
+CORS_EXPOSED_HEADERS="Directus-File-Id"
+```
+
+If you already expose other headers, keep them comma-separated:
+
+```
+CORS_EXPOSED_HEADERS="Content-Range,Directus-File-Id"
+```
+
+This is only necessary when the browser and the Directus API are on different origins. Same-origin requests (including reverse-proxied setups where the API shares the app's origin) read the header without any CORS configuration.
+
+::
+
 ## Assets
 
 | Variable                                 | Description                                                                                                                          | Default Value |


### PR DESCRIPTION
Fixes directus/docs#599.

When a chunked (TUS) upload finishes, Directus returns the resulting file id in the `Directus-File-Id` response header rather than in the body. Browsers hide non-safelisted response headers across origins unless the server opts them in via `Access-Control-Expose-Headers`, so if the Data Studio or your app is on a different origin than the API, `response.headers.get('Directus-File-Id')` just returns null. The reporter on #599 said it took hours to realise that's what was going on, and @ComfortablyCoding asked for this to be documented rather than exposed by default.

The change is a single info callout at the end of the Chunked Uploads section in `content/configuration/files.md`. It names the header, explains why the browser hides it, shows the minimal `CORS_EXPOSED_HEADERS="Directus-File-Id"` value, and shows the comma-joined form `Content-Range,Directus-File-Id` so people already using the `Content-Range` default don't accidentally drop it.

I double-checked the link target `/configuration/security-limits#cors` still exists and that the existing default there is `Content-Range`, so the combined example is accurate.

- [x] Documentation Update
- [x] I have read the contribution guidelines.