### PR TITLE
docs(files): note CORS_EXPOSED_HEADERS requirement for TUS Directus-File-Id

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -126,6 +126,12 @@ This feature requires the `PUBLIC_URL` to be set correctly to [where your API is
 
 ::
 
+::callout{icon="material-symbols:info-outline"}
+
+When calling the TUS endpoints from a browser on a different origin than the API, the uploaded file's ID is returned in a `Directus-File-Id` response header. Browsers only expose custom response headers to JavaScript when they are listed in `Access-Control-Expose-Headers`, so add `Directus-File-Id` to [`CORS_EXPOSED_HEADERS`](/configuration/security-limits#cors) (which defaults to `Content-Range`) so your frontend can read it.
+
+::
+
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
 
 **Chunked Upload Restrictions**<br/>
@@ -161,3 +167,4 @@ Image transformations can be heavy on memory usage. If you're using a system wit
 | `IMPORT_EXPORT_NAMESPACE` | Redis namespace for storing import/export information | `import-export` |
 | `IMPORT_TIMEOUT`          | Allowed duration for importing files                  | `1m`            |
 | `IMPORT_CONCURRENT_MAX`   | Maximum simultainous imports                          | `10`            |
+


### PR DESCRIPTION
Fixes #599.

`v11.16+` returns the uploaded file's ID in a `Directus-File-Id` response header after a TUS chunked upload. When the frontend is on a different origin from the API, browsers don't expose that header to JavaScript unless it's listed in `Access-Control-Expose-Headers`, so reading the ID from `xhr.getResponseHeader('Directus-File-Id')` silently returns `null`.

I hit this myself and spent a while staring at the Network tab before finding the issue, which is also the exact gotcha the report describes. ComfortablyCoding confirmed on the issue that the right fix is documentation -- not a default change -- so I added a small callout in the existing Chunked Uploads section pointing at `CORS_EXPOSED_HEADERS` on the Security & Limits page.

No variable or behavior changes, just the note.
