### PR TITLE
docs(general): warn about empty TZ env breaking internal cron scheduler

### DIFF
--- a/content/configuration/1.general.md
+++ b/content/configuration/1.general.md
@@ -24,6 +24,14 @@ description: Configuration for the general system, server, first admin user, and
 | `ACCEPT_TERMS`                             | Confirm acknowledgement of the [Directus BSL License 1.1](https://directus.io/bsl) and disable the license welcome banner.                                          | `false`                      |
 | `PROJECT_OWNER`                            | Registered owner and primary contact responsible for your Directus instance. We need this to ensure compliance with our [BSL 1.1 license](https://directus.io/bsl). |                              |
 
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+
+**Time zone (`TZ`)**<br/>
+
+Directus's internal scheduler (used for telemetry, TUS cleanup, and other cron-driven jobs) reads the process's `TZ` environment variable. Leaving `TZ` set to an _empty_ string causes startup to fail with `CronError: ERROR: You specified an invalid date`. Either leave `TZ` unset or set it to a valid IANA time zone such as `UTC` or `Europe/Berlin`.
+
+::
+
 ## Server
 
 | Variable                    | Description                                                        | Default Value                                                                                                |


### PR DESCRIPTION
Fixes #512.

Tracing the [`CronError: ERROR: You specified an invalid date`](https://github.com/directus/docs/issues/512) reported in Dec 2025 ended up exactly where @the-other-dev landed on the thread: Directus 11.13 swapped `node-schedule` for [`cron`](https://github.com/directus/directus/pull/25874), and `cron` reads the process `TZ` env var (which `node-schedule` ignored). Setting `TZ=""` (empty string, which is what some orchestrators like UnRAID emit by default) now crashes the telemetry scheduler at startup before anything else can run, and the same would affect TUS cleanup and any `schedule` flow operations.

ComfortablyCoding asked on the issue to document this rather than change defaults, so I added a single warning callout in `configuration/general.md` right after the main env-var table that tells people to either leave `TZ` unset or set it to a valid IANA zone.

Only text change; no variable additions.
