### PR TITLE
docs(email): document required IAM permissions for SES transport

### DIFF
--- a/content/configuration/email.md
+++ b/content/configuration/email.md
@@ -50,6 +50,19 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide additional variables.
 | `EMAIL_SES_CREDENTIALS__SECRET_ACCESS_KEY` | Your AWS SES secret key.    |               |
 | `EMAIL_SES_REGION`                         | Your AWS SES region.        |               |
 
+::callout{icon="material-symbols:info-outline"}
+
+**Required IAM permissions**<br/>
+
+For the SES transport to both send email and pass the `/server/health` check, the IAM identity used by `EMAIL_SES_CREDENTIALS__ACCESS_KEY_ID` needs:
+
+- **Actions**: `ses:GetAccount` and `ses:SendRawEmail`.
+- **Resources**: the verified SES identity that matches `EMAIL_FROM`, plus the dummy identity `arn:aws:ses:<EMAIL_SES_REGION>:<account-id>:identity/invalid@invalid` that Directus hits during the email health check.
+
+If `ses:GetAccount` or the `invalid@invalid` identity is missing, password-reset emails still send but `/server/health` returns a confusing `Converting circular structure to JSON` error.
+
+::
+
 ## Email Templates
 
 Templates can be used to add custom templates for your emails, or to override the system emails used for things like resetting a password or inviting a user.


### PR DESCRIPTION
Fixes #618.

Setting up AWS SES for an instance this week, I hit exactly the issue described in the report: password-reset emails were sending fine with `ses:SendRawEmail` on the verified identity, but `/server/health` kept returning `Converting circular structure to JSON`, which on the surface looks like a Directus internal error.

Tracing it, two things are needed that aren't obvious from the IAM policy side:
- `ses:GetAccount` is called by the health check, not by send.
- Directus pings a dummy `invalid@invalid` identity in `EMAIL_SES_REGION` as part of the health check; if the IAM resource list doesn't include that identity, the underlying SDK throws an error that then trips the JSON-serializer on the circular request/response pair.

I added a small info callout right under the AWS SES variable table with the minimal action + resource list and a pointer at the "confusing JSON error" symptom so anyone Googling it lands here. No variable or behavior changes.
