### PR TITLE
docs(hooks): note DB default values are not included in hook payloads

### DIFF
--- a/content/_partials/extension-hook-footguns.md
+++ b/content/_partials/extension-hook-footguns.md
@@ -1,1 +1,3 @@
 Directus reads system collections to operate. Be careful when modifying the output of system collection `read` or `query` events. Also ensure not to directly or indirectly emit the same event your hook is handling or you will create an infinite loop.
+
+Database default values are applied by the database _after_ the payload reaches your hook, so fields left at their default are omitted from both `filter` and `action` hook payloads. If your hook needs the final stored record, query it explicitly inside the callback. As a rule of thumb: use field presets when you want a value to appear in the hook payload, and database defaults when it's fine for the hook to not see it.


### PR DESCRIPTION
Fixes #449.

ComfortablyCoding confirmed on the issue that this is expected behavior: the filter/action hook payload is the client-submitted payload, not the post-insert record, so any field left at its database default value is absent from `meta.payload` even though it does land in the row once the database writes it. Reporters keep hitting it because the hook docs describe `payload` as "data associated with the event" without spelling out what _isn't_ in there.

I added one sentence to the existing `extension-hook-footguns` partial (which is only included from `guides/09.extensions/2.api-extensions/1.hooks.md`) pointing out that DB defaults aren't present in the hook payload, what to do instead (query the record if you need the full row, or use field presets if you want the value to appear), with a rule-of-thumb split between presets and DB defaults. No behavior changes; the surrounding footgun text is untouched.
