### PR TITLE
docs(database): document self-signed CA setup for managed databases

### DIFF
--- a/content/configuration/database.md
+++ b/content/configuration/database.md
@@ -33,3 +33,30 @@ This includes:
 **Note**  
 `DB_SSL__CA_FILE` may be preferred to load the CA directly from a file.
 ::
+
+## Self-Signed Certificates
+
+Managed databases such as Heroku Postgres or DigitalOcean Managed PostgreSQL typically require SSL with a self-signed CA certificate. Node's default TLS trust store does not include those CAs, so a bare connection fails with:
+
+```
+Error: self-signed certificate in certificate chain
+    code: 'SELF_SIGNED_CERT_IN_CHAIN'
+```
+
+Point Directus at the provider-issued CA file (in PEM format) using the built-in `DB_SSL__*` variables:
+
+```
+DB_CONNECTION_STRING=postgresql://user:pass@host:5432/db
+DB_SSL__REJECT_UNAUTHORIZED=true
+DB_SSL__CA_FILE=/absolute/path/to/managed-ca.crt
+```
+
+Alternatively, add the CA to Node's global trust store with [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile), which also applies to other outbound TLS connections Directus makes (SMTP, external webhooks, and so on):
+
+```
+NODE_EXTRA_CA_CERTS=/absolute/path/to/managed-ca.crt
+```
+
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Do not set `DB_SSL__REJECT_UNAUTHORIZED=false` (or the process-wide `NODE_TLS_REJECT_UNAUTHORIZED=0`) in production.** It disables verification of the server's certificate entirely, not just the CA chain, which exposes database traffic to man-in-the-middle attacks. Provide the managed provider's CA file instead.
+::


### PR DESCRIPTION
Fixes #556.

Followed up on the trail @ddelange laid down in directus/directus#16857: managed Postgres providers (Heroku, DigitalOcean, Supabase, etc.) ship a self-signed CA, Node's default trust store doesn't know about it, and the failure mode is the somewhat-unhelpful `SELF_SIGNED_CERT_IN_CHAIN` error. People then reach for `DB_SSL__REJECT_UNAUTHORIZED=false` or set `NODE_TLS_REJECT_UNAUTHORIZED=0`, which "fixes" the error but is a MITM hole in production.

ComfortablyCoding and rijkvanzanten both suggested in-thread that the right home for this is the database docs. @jacobsandersen said he might take it in Feb but hasn't opened a PR since, so I wrote it up here.

Added a new "Self-Signed Certificates" section right after the existing `DB_SSL__CA_FILE` note with:
- A sample using `DB_SSL__CA_FILE` (the path-on-disk variant Directus already exposes).
- An alternative using Node's built-in `NODE_EXTRA_CA_CERTS`, which is a cleaner fit when the same CA covers SMTP / webhook / other outbound TLS.
- A warning callout flagging `DB_SSL__REJECT_UNAUTHORIZED=false` and `NODE_TLS_REJECT_UNAUTHORIZED=0` as production footguns.

No variables added.
