### PR TITLE
docs(getting-started): flag the quickstart compose as non-production

### DIFF
--- a/content/getting-started/2.create-a-project.md
+++ b/content/getting-started/2.create-a-project.md
@@ -94,7 +94,10 @@ docker compose up
 
 Directus should now be available at http://localhost:8055 or http://127.0.0.1:8055, where you'll see an onboarding screen to configure your first Admin account.
 
-The project that runs from this `docker-compose.yml` file is not production-ready but enough to use many features.
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Not production-ready**<br/>
+This example uses SQLite, no cache, and placeholder credentials -- enough to explore most features locally, but missing the database, cache, and secret management you want in production. For a managed setup, use [Directus Cloud](https://directus.cloud/). For self-hosting, start from the [Postgres + Redis Docker Compose example](/self-hosting/deploying#docker-compose-examples) and review the [self-hosting requirements](/self-hosting/requirements).
+::
 
 ## Deploy Directus
 


### PR DESCRIPTION
Fixes #475.

The existing line "The project that runs from this docker-compose.yml file is not production-ready but enough to use many features" is easy to skim past, especially right after the success state where the app is already loading at `localhost:8055`. Community thread linked on the issue shows people carrying the SQLite + no-cache quickstart into production and running into exactly the issues that setup doesn't handle.

Replaced the sentence with a warning callout that:
- Calls out what's not production-ready (SQLite, no cache, placeholder credentials).
- Points at Directus Cloud for the managed path.
- Points at the existing [Postgres + Redis Docker Compose example](https://directus.io/docs/self-hosting/deploying#docker-compose-examples) already living in `self-hosting/deploying.md` for the self-hosted path.
- Points at the [self-hosting requirements page](/self-hosting/requirements) so nobody skips the sizing / persistence checks.

One-file change; no new content added beyond the callout.
