### PR TITLE
docs(auth-sso): note cookie-mode providers are hidden from login page

### DIFF
--- a/content/configuration/auth-sso.md
+++ b/content/configuration/auth-sso.md
@@ -26,6 +26,11 @@ For each of the auth providers listed, you must provide the following configurat
 Cookie and session configuration settings such as `REFRESH_TOKEN_COOKIE_*`, `SESSION_COOKIE_*`, and related security parameters can be found in [Security & Limits](/configuration/security-limits).
 ::
 
+::callout{icon="material-symbols:info-outline"}
+**Cookie-mode providers are hidden from the Data Studio login page.**<br/>
+Only providers in the default `session` mode render a sign-in button on `/admin/login`. Providers configured with `AUTH_<PROVIDER>_MODE=cookie` are still fully functional for programmatic and API sign-in flows but will not appear on the Studio login screen (see [directus/directus#21874](https://github.com/directus/directus/pull/21874)). If an expected provider is missing from the login page, confirm that its `AUTH_<PROVIDER>_MODE` is set to `session`.
+::
+
 Based on your configured drivers, you must also provide additional variables, where `<PROVIDER>` is the capitalized name of the item in the `AUTH_PROVIDERS` value.
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}


### PR DESCRIPTION
Fixes #473.

Ran into this while wiring up a second OIDC provider in cookie mode: the login button just never showed up, even though the provider was otherwise working end-to-end via the callback URL. Tracked it back to directus/directus#21874, which intentionally hides non-session providers from `/admin/login` (they can't produce a Studio session cookie the UI can use). That behaviour has been live since v10.10.5 but there is no doc mention, so reporters keep hitting the same "why is my login button missing" wall.

Added a single info callout right under the existing cookie/session security callout on the `auth-sso` page that:
- Spells out that only `session`-mode providers render on the Studio login page.
- Confirms cookie-mode providers still work for programmatic/API sign-in.
- Links to directus/directus#21874 so anyone searching the error lands here.
- Points at `AUTH_<PROVIDER>_MODE` as the thing to double-check when a provider is missing.

No variable changes.
