### PR TITLE
docs(files): document STORAGE_<LOCATION>_CREDENTIALS for GCS driver

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -57,10 +57,13 @@ Based on your configured drivers, you must also provide additional variables, wh
 
 ### Google Cloud Storage (`gcs`)
 
-| Variable                          | Description                  | Default Value |
-| --------------------------------- | ---------------------------- | ------------- |
-| `STORAGE_<LOCATION>_KEY_FILENAME` | Path to key file on disk.    |               |
-| `STORAGE_<LOCATION>_BUCKET`       | Google Cloud Storage bucket. |               |
+| Variable                          | Description                                                                                                                                                          | Default Value |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `STORAGE_<LOCATION>_KEY_FILENAME` | Path to the service account key file on disk.                                                                                                                        |               |
+| `STORAGE_<LOCATION>_CREDENTIALS`  | Inline service account key as a JSON object, passed through to the Google Cloud Storage client. Use the `json:` prefix, for example `json:{"client_email":"..."}`.   |               |
+| `STORAGE_<LOCATION>_BUCKET`       | Google Cloud Storage bucket.                                                                                                                                         |               |
+
+Set either `STORAGE_<LOCATION>_KEY_FILENAME` or `STORAGE_<LOCATION>_CREDENTIALS`, not both. `KEY_FILENAME` is useful when mounting the key as a Docker secret or volume; `CREDENTIALS` is useful when the hosting platform injects the key as an environment variable. See the [Environment Syntax Prefix](/configuration#environment-syntax-prefix) section for how the `json:` prefix is parsed.
 
 ### Azure (`azure`)
 


### PR DESCRIPTION
Fixes #324.

The report traces a GCP deployment-blog trail-off: the tutorial at `/blog/deploying-directus-to-google-cloud-platform-with-docker` used `STORAGE_<LOCATION>_CREDENTIALS` with a `json:` prefix, but the variable was never listed in the files config reference, so anyone landing on that page to configure GCS by hand had no way to discover it. Reading `packages/storage-driver-gcs/src/index.ts`, the driver destructures `bucket`, `root`, `apiEndpoint`, and `tus`, then spreads the remainder into the `@google-cloud/storage` `Storage` constructor -- so `credentials` is a valid passthrough (the SDK accepts an inline service-account JSON), but it is GCS-only (S3/Azure/Supabase/Cloudinary each read their own shaped creds).

Added one row to the GCS table in `content/configuration/files.md` for `STORAGE_<LOCATION>_CREDENTIALS`, plus a short paragraph that:
- Makes the `KEY_FILENAME` vs `CREDENTIALS` choice explicit ("pick one, not both"), aligning with the typical Docker-secret vs PaaS-env split the reporter ran into.
- Points at the existing [Environment Syntax Prefix](/configuration#environment-syntax-prefix) section so the `json:` prefix is learnable from here without copy-pasting docs.

No new env var, just documenting the one already flowing through.
