### PR TITLE
docs(partials): mark json function as fields-only in shared functions table

### DIFF
--- a/content/_partials/query-functions.md
+++ b/content/_partials/query-functions.md
@@ -2,15 +2,17 @@ Functions accept a field and return a modified value. Functions can be used in a
 
 The syntax for using a function is `function(field)`.
 
-| Function  | Description                                                       |
-| --------- | ----------------------------------------------------------------- |
-| `year`    | Extract the year from a datetime/date/timestamp field             |
-| `month`   | Extract the month from a datetime/date/timestamp field            |
-| `week`    | Extract the week from a datetime/date/timestamp field             |
-| `day`     | Extract the day from a datetime/date/timestamp field              |
-| `weekday` | Extract the weekday from a datetime/date/timestamp field          |
-| `hour`    | Extract the hour from a datetime/date/timestamp field             |
-| `minute`  | Extract the minute from a datetime/date/timestamp field           |
-| `second`  | Extract the second from a datetime/date/timestamp field           |
-| `count`   | Extract the number of items from a JSON array or relational field |
-| `json`    | Extract a specific value from a JSON field using path notation    |
+| Function              | Description                                                       |
+| --------------------- | ----------------------------------------------------------------- |
+| `year`                | Extract the year from a datetime/date/timestamp field             |
+| `month`               | Extract the month from a datetime/date/timestamp field            |
+| `week`                | Extract the week from a datetime/date/timestamp field             |
+| `day`                 | Extract the day from a datetime/date/timestamp field              |
+| `weekday`             | Extract the weekday from a datetime/date/timestamp field          |
+| `hour`                | Extract the hour from a datetime/date/timestamp field             |
+| `minute`              | Extract the minute from a datetime/date/timestamp field           |
+| `second`              | Extract the second from a datetime/date/timestamp field           |
+| `count`               | Extract the number of items from a JSON array or relational field |
+| `json` <sup>[1]</sup> | Extract a specific value from a JSON field using path notation    |
+
+<sup>[1]</sup> `json(field, path)` is only supported in the `fields` query parameter. It cannot be used in filters, aggregation, or other parameters.


### PR DESCRIPTION
Fixes #591.

The shared `content/_partials/query-functions.md` is rendered via `:partial{content="query-functions"}` on two pages:
- `guides/04.connect/2.filter-rules.md` -> Functions Parameters (filters)
- `guides/04.connect/3.query-parameters.md` -> Functions (field selection)

`json(field, path)` is only valid in the `fields` query parameter (confirmed by the existing `_partials/json-function.md`, which prominently says: "the `json(field, path)` function is currently only supported for use in the `fields` query parameter"). But because the table is shared, it also shows up on the filter-rules page where it doesn't apply.

Rather than splitting the partial (which would duplicate the eight datetime/count rows across two files and make future edits drift), I kept the single source of truth and added a `<sup>[1]</sup>` footnote next to the `json` row, matching the footnote style already used on `filter-rules.md` for operators with restrictions (`_regex`, `_some`, `_none`, etc.). The footnote explicitly calls out that `json` is fields-only and cannot be used in filters or aggregation.

Now both rendering locations show the row, but the restriction is visible at the point of use.
