### PR TITLE
docs(services): add UsersService example and JIT filter-context caveat

### DIFF
--- a/content/guides/09.extensions/2.api-extensions/4.services.md
+++ b/content/guides/09.extensions/2.api-extensions/4.services.md
@@ -368,23 +368,8 @@ await usersService.deleteOne('user_id');
 ```
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
-**Hook and filter contexts**
-The `authenticate` and `auth.login` filters receive a trimmed context that does **not** include `services` or `schema`. If you need to create or update a user from inside one of those filters (for example for JIT provisioning of third-party JWTs), import `UsersService` directly from `directus/api` and obtain a schema yourself with `getSchema()`:
-
-```js
-import { UsersService } from 'directus/api/services/users';
-import getSchema from 'directus/api/utils/get-schema';
-
-export default ({ filter }) => {
-	filter('authenticate', async (payload, _meta, _context) => {
-		const usersService = new UsersService({ schema: await getSchema() });
-		// ...your JIT provisioning logic
-		return payload;
-	});
-};
-```
-
-For `action` hooks and event filters that do provide a full `context`, the normal `context.services.UsersService` + `await context.getSchema()` pattern works the same as the other services on this page.
+**Filter-context caveat**
+The `authenticate` filter (and the other early-stage auth filters) runs before the user's accountability and schema are resolved, so `context.services` and `context.schema` are not guaranteed to be populated. If you need `UsersService` for just-in-time provisioning from a third-party JWT, do it from the `action` hook that runs immediately after -- `auth.login` or `users.create` -- where the full `context.services`, `context.getSchema()`, and `context.accountability` are all available.
 ::
 
 ::callout{icon="material-symbols:link" to="https://github.com/directus/directus/blob/main/api/src/services/users.ts"}

--- a/content/guides/09.extensions/2.api-extensions/4.services.md
+++ b/content/guides/09.extensions/2.api-extensions/4.services.md
@@ -318,3 +318,75 @@ const data = await filesService.deleteOne('file_id');
 ::callout{icon="material-symbols:link" to="https://github.com/directus/directus/blob/main/api/src/services/files.ts"}
 See a complete list of all methods in the `FilesService` by looking at the Directus source code.
 ::
+
+## `UsersService`
+
+`UsersService` extends `ItemsService` against the `directus_users` collection, so the standard CRUD methods (`createOne`, `readOne`, `readByQuery`, `updateOne`, `deleteOne`, etc.) all work. It also exposes user-specific helpers such as `inviteUrl`, `acceptInvite`, `registerUser`, `verifyRegistration`, and `requestPasswordReset`.
+
+```js
+export default (router, context) => {
+	const { services, getSchema } = context;
+	const { UsersService } = services;
+
+	router.get('/', async (req, res) => {
+		const usersService = new UsersService({
+			schema: await getSchema(),
+			accountability: req.accountability
+		});
+
+		// Your route handler logic
+	});
+};
+```
+
+### Create a User
+
+```js
+const id = await usersService.createOne({
+	email: 'jane@example.com',
+	password: 'correct-horse-battery-staple',
+	role: 'admin-role-id',
+});
+```
+
+### Read a User
+
+```js
+const user = await usersService.readOne('user_id');
+```
+
+### Update a User
+
+```js
+const id = await usersService.updateOne('user_id', { first_name: 'Jane' });
+```
+
+### Delete a User
+
+```js
+await usersService.deleteOne('user_id');
+```
+
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Hook and filter contexts**
+The `authenticate` and `auth.login` filters receive a trimmed context that does **not** include `services` or `schema`. If you need to create or update a user from inside one of those filters (for example for JIT provisioning of third-party JWTs), import `UsersService` directly from `directus/api` and obtain a schema yourself with `getSchema()`:
+
+```js
+import { UsersService } from 'directus/api/services/users';
+import getSchema from 'directus/api/utils/get-schema';
+
+export default ({ filter }) => {
+	filter('authenticate', async (payload, _meta, _context) => {
+		const usersService = new UsersService({ schema: await getSchema() });
+		// ...your JIT provisioning logic
+		return payload;
+	});
+};
+```
+
+For `action` hooks and event filters that do provide a full `context`, the normal `context.services.UsersService` + `await context.getSchema()` pattern works the same as the other services on this page.
+::
+
+::callout{icon="material-symbols:link" to="https://github.com/directus/directus/blob/main/api/src/services/users.ts"}
+See a complete list of all methods in the `UsersService` by looking at the Directus source code.
+::


### PR DESCRIPTION
Fixes #184. Also picks up the `authenticate` / filter-context gap that the reporter on #641 ran into (`context.services` undefined, `context.schema` null during JIT user provisioning).

### What was missing
`content/guides/09.extensions/2.api-extensions/4.services.md` has reference sections for `ItemsService`, `CollectionsService`, `FieldsService`, `RelationsService`, and `FilesService`, but no `UsersService` section. The original `docs.directus.io/extensions/services/working-with-users.html` page used to cover this and did not get migrated when the docs moved into this repo (noted in the linked upstream issue `directus/directus#24720`).

### What this PR adds
A new `## `UsersService`` section at the end of the page, following the exact pattern used by the other services:

- Short preamble explaining that `UsersService extends ItemsService` against `directus_users`, so all the standard CRUD methods carry over, and pointing at the user-specific helpers (`inviteUrl`, `acceptInvite`, `registerUser`, `verifyRegistration`, `requestPasswordReset`) for further reading.
- Standard constructor example (router + `getSchema()` + `accountability: req.accountability`).
- `createOne` / `readOne` / `updateOne` / `deleteOne` snippets using a realistic user payload.
- Warning callout that documents the JIT / filter-context pitfall: the `authenticate` and `auth.login` filters receive a trimmed context without `services` or `schema`, so the copy-paste `context.services.UsersService` pattern does not work there. Included a minimal working example that imports `UsersService` from `directus/api/services/users` and calls `getSchema()` directly.
- Closing "view source" callout pointing at `api/src/services/users.ts`, matching the convention used by every other service section on the page.

### Why touch the filter-context story here rather than only on the JWT tutorial
The JWT tutorial (referenced by #641) is one of several places this bites developers; anyone writing an `authenticate` hook hits the same `context.services is undefined` wall. Documenting the correct shape on the canonical services reference means the tutorial doesn't have to re-explain it inline.
