### PR TITLE
docs(visual-editor): note singleton item is the stored row primary key

### DIFF
--- a/content/guides/02.content/8.visual-editor/1.frontend-library.md
+++ b/content/guides/02.content/8.visual-editor/1.frontend-library.md
@@ -57,7 +57,7 @@ The `fields` property in the `setAttr` function can also accept an array of stri
 | Option | Type | Description |
 | ------ | ---- | ----------- |
 | `collection`  | `string`                           | Name of the relevant collection. This is required. |
-| `item`        | `string`, `number`                 | Primary key of the item. This is required. |
+| `item`        | `string`, `number`                 | Primary key of the item. This is required. For singleton collections, pass the primary key of the stored row (typically `1`). |
 | `fields`      | `string`, `string[]`               | The specific fields to show when editing. Optional, otherwise all fields will be shown. |
 | `mode`        | `'drawer'`, `'modal'`, `'popover'` | Determines how the edit field(s) should be rendered. Optional, but defaults to `'drawer'` |
 
@@ -104,7 +104,7 @@ The optional `onSaved` callback function of the `apply()` method provides an obj
 | Property | Type | Description |
 | --------- | ---- | ----------- |
 | `collection` | `string`              | Name of the relevant collection. |
-| `item` | `string`, `number` | Primary key of the item. |
+| `item` | `string`, `number` | Primary key of the item. For singleton collections, this will be the primary key of the stored row (typically `1`). |
 | `payload` | `Record<string, any>` | The changed values. |
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}


### PR DESCRIPTION
Fixes #420.

The `item` option in both `setAttr()` and `openDrawer()` is documented as *'Primary key of the item. This is required.'* For regular collections that's enough, but for singletons the natural first instinct is to omit `item` (because conceptually there is only one), and the editor then silently fails to open. The reporter burned ~30 minutes before guessing `item: 1`.

### Change

`content/guides/02.content/8.visual-editor/1.frontend-library.md` -- added a one-line clause to the two option tables that already document `item`:

- `setAttr()` (line 60): `Primary key of the item. This is required. For singleton collections, pass the primary key of the stored row (typically 1).`
- `openDrawer()` (line 107): `Primary key of the item. For singleton collections, this will be the primary key of the stored row (typically 1).`

No other surface changes -- keeping the note inline with the existing option row, so it shows up where readers are already looking.