### PR TITLE
fix(tutorials): wrap long tutorial titles on Firefox and Safari

### DIFF
--- a/app/components/TutorialsArticles.vue
+++ b/app/components/TutorialsArticles.vue
@@ -50,7 +50,7 @@ const imageSrc = (article: { technologies?: string[] }) => {
 						alt="Generated Image"
 					>
 					<div class="col-span-2">
-						<ProseP class="text-gray-900 dark:text-white text-base truncate font-bold text-pretty">
+						<ProseP class="text-gray-900 dark:text-white text-base line-clamp-2 font-bold text-pretty">
 							{{ article.title }}
 						</ProseP>
 						<ProseP class="text-[15px] text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">


### PR DESCRIPTION
Fixes #464.

The tutorial card title in `app/components/TutorialsArticles.vue` uses the Tailwind `truncate` utility, which applies `white-space: nowrap` plus `overflow: hidden` + `text-overflow: ellipsis`. On Firefox and Safari any tutorial title that doesn't fit the card width is clamped to a single line with an ellipsis instead of wrapping onto a second line.

Replace `truncate` with `line-clamp-2` so:

- Titles wrap onto a second line on all browsers.
- Anything longer than two lines still collapses with an ellipsis, so the card height stays stable.
- Behaviour matches the description immediately below, which already uses `line-clamp-2`.

Left `text-pretty` in place because it's a progressive enhancement and not the cause of the clipping -- Firefox simply ignores it today.

### Before / after

- Firefox / Safari before: long titles truncated on a single line.
- All browsers after: two-line wrap with ellipsis beyond that. Description line-clamp unchanged.