### PR TITLE
docs(api): document update-by-query and delete-by-query on /items/{collection}

### DIFF
--- a/public/oas.yaml
+++ b/public/oas.yaml
@@ -3481,7 +3481,14 @@ paths:
             }
     patch:
       summary: Update Multiple Items
-      description: Update multiple items at the same time.
+      description: |
+        Update multiple items at the same time.
+
+        Choose between three body formats:
+
+        - An **array** of item objects that include the primary key -- each object is upserted in a batch (`updateBatch`).
+        - An object with `data` and `keys` -- applies the same partial `data` to every item whose primary key is listed in `keys` (`updateMany`).
+        - An object with `data` and `query` -- applies the same partial `data` to every item that matches the query, using the same [filter syntax](/guides/connect/filter-rules) accepted by the `GET` endpoint (`updateByQuery`).
       operationId: updateItems
       parameters:
         - $ref: '#/components/parameters/Collection'
@@ -3496,17 +3503,33 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - data
-                - keys
-              properties:
-                data:
-                  $ref: '#/components/schemas/Items'
-                keys:
-                  type: array
+              anyOf:
+                - type: array
+                  description: Array of item objects to batch-update. Each object must include its primary key.
                   items:
-                    type: string
+                    $ref: '#/components/schemas/Items'
+                - type: object
+                  description: Update items by primary key (`updateMany`). The same `data` is applied to every item whose key is listed.
+                  required:
+                    - data
+                    - keys
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/Items'
+                    keys:
+                      type: array
+                      items:
+                        type: string
+                - type: object
+                  description: Update items by query (`updateByQuery`). The same `data` is applied to every item matched by the query.
+                  required:
+                    - data
+                    - query
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/Items'
+                    query:
+                      $ref: '#/components/schemas/Query'
       responses:
         '200':
           description: Successful request
@@ -3545,7 +3568,14 @@ paths:
             }
     delete:
       summary: Delete Multiple Items
-      description: Delete multiple items at the same time.
+      description: |
+        Delete multiple items at the same time.
+
+        Choose between three body formats:
+
+        - An **array** of primary keys -- every item with a matching key is deleted (`deleteMany`).
+        - An object with `keys` -- same as the array form, for consistency with the update endpoints (`deleteMany`).
+        - An object with `query` -- every item that matches the query is deleted, using the same [filter syntax](/guides/connect/filter-rules) accepted by the `GET` endpoint (`deleteByQuery`).
       operationId: deleteItems
       parameters:
         - $ref: '#/components/parameters/Collection'
@@ -3562,18 +3592,25 @@ paths:
             schema:
               anyOf:
                 - type: array
-                  description: Primary keys of items to be deleted.
+                  description: Primary keys of items to be deleted (`deleteMany`).
                   items:
                     type: string
                 - type: object
-                  description: Object containing either `keys` or `query` to selected what items to update.
+                  description: Delete items by primary key (`deleteMany`).
+                  required:
+                    - keys
                   properties:
                     keys:
                       type: array
                       items:
                         type: string
-                    items:
-                      type: object
+                - type: object
+                  description: Delete items by query (`deleteByQuery`). Every item matched by the query is deleted.
+                  required:
+                    - query
+                  properties:
+                    query:
+                      $ref: '#/components/schemas/Query'
       responses:
         '204':
           description: The resource was deleted successfully.


### PR DESCRIPTION
Fixes #607.

The `PATCH /items/{collection}` and `DELETE /items/{collection}` endpoints each support three body shapes in the controller (see `api/src/controllers/items.ts`):

- `updateBatch` / `deleteMany(body)` — an **array**.
- `updateMany` / `deleteMany(body.keys)` — an object with **keys**.
- `updateByQuery` / `deleteByQuery` — an object with **query**.

The rendered API reference (`public/oas.yaml`) only exposed the `keys` variant for PATCH and a partially-shaped object for DELETE, so users following the reference had no way to discover the `updateByQuery` / `deleteByQuery` behaviour that #607 is asking about.

### What this PR does

- Replaces PATCH `requestBody` with an `anyOf` of three variants and adds descriptions that name the backing service method (`updateBatch`, `updateMany`, `updateByQuery`).
- Does the same for DELETE (`anyOf` of array / `{keys}` / `{query}`).
- Points the `query` variant at the existing `Query` schema so filter / sort / limit / search render inline in the reference.
- Expands the top-level operation `description` to call out the three modes with a one-liner each, so the reference is readable without expanding the schema tree.

### Notes

- No behaviour changes — this is purely an OAS spec update for the rendered reference.
- I noticed `/items/{collection}/singleton` is still in `oas.yaml` on `main`; my other PR #653 removes it. If #653 lands first I'll rebase; if this lands first #653 will rebase. No conflict on the specific PATCH/DELETE block touched here.
- Didn't change the GraphQL code sample because GraphQL uses `delete_<collection>_items` / `update_<collection>_items` with ids only. The REST-only by-query path is what the issue is about.