### PR TITLE
fix(api): declare object type on utility request body schemas

### DIFF
--- a/public/oas.yaml
+++ b/public/oas.yaml
@@ -8911,6 +8911,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               properties:
                 format:
                   type: string
@@ -8950,6 +8951,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               properties:
                 string:
                   type: string
@@ -8991,6 +8993,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               properties:
                 string:
                   type: string
@@ -9124,6 +9127,7 @@ paths:
         content:
           application/json:
             schema:
+              type: object
               properties:
                 item:
                   type: number


### PR DESCRIPTION
Fixes #474.

## The bug

The scalar-based API reference (e.g. [Export Data to a File](https://directus.io/docs/api/utilities#export-data-to-a-file)) currently renders the Request Body panel as `[undefined]` on four Utilities endpoints, which hides the required `query` / `format` / `file` / `string` / `hash` fields entirely. Callers then hit errors like `Invalid payload. query is required` with no hint from the docs about what body shape to send.

## The cause

Inside `public/oas.yaml` the following schemas declare `properties` directly under `schema:` without an explicit `type`:

- `POST /utils/export/{collection}`
- `POST /utils/hash/generate`
- `POST /utils/hash/verify`
- `POST /utils/sort/{collection}`

Scalar's renderer walks the schema using the declared type; with no type set it treats the node as untyped and outputs `[undefined]`. Every other request body in `oas.yaml` already declares `type: object` (or `type: array` / `anyOf`) explicitly -- these four are the outliers.

## The fix

Add `type: object` to each of the four affected schemas. Nothing else is changed -- the existing `properties` and `required` blocks already match the controller behaviour (verified against `api/src/controllers/utils.ts` in `directus/directus`: export requires `format`, `query`, `file`; hash-generate requires `string`; hash-verify requires `string` + `hash`; sort expects `item` + `to`).

After this change the Request Body panel on each of those pages shows the full object schema with the required markers and the existing SDK code sample.