### PR TITLE
docs: clarify cache key derivation on cache configuration page

### DIFF
--- a/content/configuration/cache.md
+++ b/content/configuration/cache.md
@@ -5,11 +5,26 @@ description: Configuration for internal and output caching.
 
 :partial{content="config-env-vars"}
 
-Directus has a built-in data-caching option. Enabling this will cache the output of requests (based on the current user
-and exact query parameters used) into configured cache storage location. This drastically improves API performance, as
-subsequent requests are served straight from this cache. Enabling cache will also make Directus return accurate
-cache-control headers. Depending on your setup, this will further improve performance by caching the request in
-middleman servers (like CDNs) and even the browser.
+Directus has a built-in data-caching option. Enabling this will cache the output of requests into the configured cache
+storage location. This drastically improves API performance, as subsequent requests are served straight from this
+cache. Enabling cache will also make Directus return accurate cache-control headers. Depending on your setup, this will
+further improve performance by caching the request in middleman servers (like CDNs) and even the browser.
+
+The cache key is derived from the following:
+
+- The Directus version
+- The current user ID (or unauthenticated)
+- The request path (the URL path, excluding any query string)
+- The parsed Directus [Global Query Parameters](/guides/connect/query-parameters) (e.g. `fields`, `filter`, `sort`,
+  `limit`, `offset`, `page`, `search`, `deep`, `alias`, `aggregate`, `groupBy`, `backlink`, `export`, `version`) — not
+  arbitrary URL query parameters. For GraphQL requests, the parsed query and variables are used
+- The client IP, but only when a policy applied to the current user has an IP access filter that matches the request IP
+- For `/flows/trigger/{id}` endpoints, any raw query parameters whose names are listed in that flow's `cacheQueryParams`
+  option
+
+Arbitrary URL query parameters outside the list above do not act as a cache buster on their own; add a recognised
+parameter (for example `?version=...`), clear the cache, or disable caching per-request with `Cache-Control: no-store`
+(requires `CACHE_SKIP_ALLOWED=true`) if you need to bypass the cache.
 
 ::callout{icon="material-symbols:info-outline"}
 **Internal Caching**


### PR DESCRIPTION
Closes #414.

The current Cache configuration page says the data cache key is derived from "the current user and exact query parameters used", which led to confusion because arbitrary URL query parameters don't act as cache busters and it isn't obvious from the docs alone.

The actual key derivation lives in [`api/src/utils/get-cache-key.ts`](https://github.com/directus/directus/blob/main/api/src/utils/get-cache-key.ts) and combines:

- `version` (Directus version)
- `req.accountability?.user` (current user id, or `null`)
- `path` (`url.parse(req.originalUrl).pathname` — the URL path, without query string)
- `req.sanitizedQuery` (parsed Directus query parameters only — `fields`, `filter`, `sort`, `limit`, `offset`, `page`, `search`, `deep`, `alias`, `aggregate`, `groupBy`, `backlink`, `export`, `version`) — or the parsed GraphQL query/variables for `/graphql*`
- `rawQuery`, conditionally — for `/flows/trigger/<uuid>` only, picks whatever query param names the flow lists in its `cacheQueryParams` option
- `ip`, conditionally — only when a policy attached to the current user has an `ip_access` filter that matches the request IP

This PR replaces the inaccurate intro sentence with an explicit bulleted list mirroring the above, and adds a short note about how to bypass the cache (add a recognised Directus parameter, purge, or use `Cache-Control: no-store` with `CACHE_SKIP_ALLOWED=true`) so readers aren't surprised that `?bust=123` is a no-op.

Verified locally against `api/src/utils/get-cache-key.ts` on `directus/directus@main`.
