### PR TITLE
docs: warn about Clearbit API sunset on the two tutorials that reference it

### DIFF
--- a/content/tutorials/2.projects/build-the-leap-week-registration-and-referral-system-.md
+++ b/content/tutorials/2.projects/build-the-leap-week-registration-and-referral-system-.md
@@ -176,6 +176,12 @@ export default defineNuxtConfig({
 })
 ```
 
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+The `logo.clearbit.com` Logo API used in the proxy above [is being sunset by HubSpot on December 1, 2025](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api).
+For new projects following this pattern, swap the proxy target for an alternative such as Brandfetch, Logo.dev, or a
+self-hosted asset pipeline.
+::
+
 ## Referral Tracking
 
 We wanted to offer more chances in the giveaway for referrals so we needed to build a mechanism to control that.

--- a/content/tutorials/2.projects/build-the-leap-week-registration-and-referral-system-.md
+++ b/content/tutorials/2.projects/build-the-leap-week-registration-and-referral-system-.md
@@ -177,7 +177,7 @@ export default defineNuxtConfig({
 ```
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
-The `logo.clearbit.com` Logo API used in the proxy above [is being sunset by HubSpot on December 1, 2025](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api).
+The `logo.clearbit.com` Logo API used in the proxy above [is being sunset by HubSpot on December 8, 2025](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api).
 For new projects following this pattern, swap the proxy target for an alternative such as Brandfetch, Logo.dev, or a
 self-hosted asset pipeline.
 ::

--- a/content/tutorials/7.workflows/enrich-user-data-with-clearbit-and-directus-automate.md
+++ b/content/tutorials/7.workflows/enrich-user-data-with-clearbit-and-directus-automate.md
@@ -9,6 +9,16 @@ authors:
     title: Director, Developer Experience
 description: Learn how to integrate Clearbit data enrichment with Directus Automate.
 ---
+
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Clearbit APIs are being sunset by HubSpot.** The free `logo.clearbit.com` Logo API stops responding on December 1,
+2025, and Clearbit's other standalone enrichment APIs (including the Person Enrichment endpoint used in this tutorial)
+are being migrated into [HubSpot Breeze Intelligence](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api).
+The pattern below — trigger a flow on `items.create`, call an external enrichment endpoint, write the response back onto
+`directus_users` — still applies verbatim; just swap the URL, auth header, and payload field paths for your chosen
+provider (HubSpot Breeze Intelligence, FullContact, Apollo, People Data Labs, etc.).
+::
+
 The Directus toolkit can be used for so many different projects and use cases, with a common one being Customer Relationship Management (CRM). CRMs are often used to support sales and marketing teams in understanding who is interested in and already using a product, and have more streamlined conversations with them.
 
 When a new user is created in Directus, directly through the Data Studio or through [Directus Auth](https://directus.io/toolkit/auth), you may only collect a small amount of information about them. Historically, you may have to then do manual research to understand who a person is before messaging them.

--- a/content/tutorials/7.workflows/enrich-user-data-with-clearbit-and-directus-automate.md
+++ b/content/tutorials/7.workflows/enrich-user-data-with-clearbit-and-directus-automate.md
@@ -11,12 +11,16 @@ description: Learn how to integrate Clearbit data enrichment with Directus Autom
 ---
 
 ::callout{icon="material-symbols:warning-rounded" color="warning"}
-**Clearbit APIs are being sunset by HubSpot.** The free `logo.clearbit.com` Logo API stops responding on December 1,
-2025, and Clearbit's other standalone enrichment APIs (including the Person Enrichment endpoint used in this tutorial)
-are being migrated into [HubSpot Breeze Intelligence](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api).
-The pattern below — trigger a flow on `items.create`, call an external enrichment endpoint, write the response back onto
-`directus_users` — still applies verbatim; just swap the URL, auth header, and payload field paths for your chosen
-provider (HubSpot Breeze Intelligence, FullContact, Apollo, People Data Labs, etc.).
+Clearbit's Person Enrichment API (used in this tutorial) is no longer accepting new signups.
+Existing Clearbit and HubSpot customers can still call it, and the product is being folded into
+[HubSpot Breeze Intelligence](https://www.hubspot.com/products/breeze). Separately, the free
+`logo.clearbit.com` Logo API [shuts down on December 8, 2025](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api),
+but that endpoint is not used in this tutorial.
+
+If you already have Clearbit access, the flow below works as-is. If you're starting fresh, the same
+pattern (trigger on `items.create`, call an enrichment endpoint, write the response back onto
+`directus_users`) applies to any provider such as FullContact, Apollo, or People Data Labs; swap the
+URL, auth header, and response field paths to match.
 ::
 
 The Directus toolkit can be used for so many different projects and use cases, with a common one being Customer Relationship Management (CRM). CRMs are often used to support sales and marketing teams in understanding who is interested in and already using a product, and have more streamlined conversations with them.

--- a/msg.txt
+++ b/msg.txt
@@ -1,0 +1,8 @@
+docs(clearbit): distinguish Enrichment API legacy access from Logo API sunset
+
+Bryant pointed out on #659 that the original callout conflated two states. Rewrote it so:
+
+- Person Enrichment API: closed to new signups, still works for existing Clearbit/HubSpot customers, being folded into Breeze Intelligence.
+- Logo API: hard sunset on December 8, 2025 (not used in this tutorial).
+
+Also corrected the sunset date on the leap-week tutorial callout from Dec 1 to Dec 8 per the HubSpot changelog.


### PR DESCRIPTION
Closes #269.

HubSpot is [sunsetting Clearbit's free Logo API on December 1, 2025](https://developers.hubspot.com/changelog/upcoming-sunset-of-clearbits-free-logo-api) and is migrating the remaining standalone Clearbit endpoints (including the Person Enrichment API) into HubSpot Breeze Intelligence. Two tutorials in the docs still reference Clearbit.

This PR adds a warning callout to each so readers following either tutorial aren't surprised when the endpoints stop responding:

**`tutorials/workflows/enrich-user-data-with-clearbit-and-directus-automate.md`**
- Callout up top noting the sunset, linking HubSpot's announcement, and listing a few enrichment-API alternatives (HubSpot Breeze Intelligence, FullContact, Apollo, People Data Labs).
- Kept the body intact — the `items.create` trigger → HTTP request → payload-mapping flow pattern is provider-agnostic, so readers can swap URL + auth header + response field paths without rewriting the tutorial.

**`tutorials/projects/build-the-leap-week-registration-and-referral-system-.md`**
- Smaller callout immediately after the Nuxt `routeRules` example that proxies `https://logo.clearbit.com/**`, pointing at Brandfetch / Logo.dev / self-hosted as drop-in alternatives.

Deliberately avoided rewriting either tutorial end-to-end — the patterns themselves are still useful, and blanket rewrites felt overreaching for a deprecation-awareness fix.
