### PR TITLE
docs: warn that Schedule (CRON) triggers need a valid TZ env var

### DIFF
--- a/content/guides/06.automate/3.triggers.md
+++ b/content/guides/06.automate/3.triggers.md
@@ -99,6 +99,14 @@ This trigger type enables creating data at scheduled intervals, via
 
 - **Interval** — Set the cron job interval to schedule when the Flow triggers.
 
+::callout{icon="material-symbols:warning-rounded" color="warning"}
+**Set a valid `TZ` environment variable (or leave it unset).** Since Directus 11.13.0 the scheduler is powered by
+[`cron`](https://www.npmjs.com/package/cron), which reads the `TZ` environment variable when evaluating the next run
+time. An empty string (`TZ=""`) throws `CronError: ERROR: You specified an invalid date` and prevents Directus from
+starting. Use a valid [IANA time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `UTC` or
+`Europe/Berlin`, or remove the variable entirely so the container falls back to the node default.
+::
+
 ### Syntax Explanation
 
 ```


### PR DESCRIPTION
Closes #512.

Since Directus 11.13.0 the internal scheduler switched from `node-schedule` to [`cron`](https://www.npmjs.com/package/cron) (directus/directus#25874). Unlike node-schedule, `cron` reads the `TZ` environment variable. When `TZ` is set to an empty string — which happens on UnraidOS container templates and some other orchestrators — the scheduler throws `CronError: ERROR: You specified an invalid date` and Directus fails to start, as reported in the issue.

Maintainers asked for this to be documented, so this PR adds a warning callout right under the **Schedule (CRON)** section of the Flow triggers guide. The callout:

- Points out the 11.13.0 switch from node-schedule to cron as the cause.
- Shows the exact error string so operators searching for it land here.
- Tells them to either set `TZ` to a valid IANA zone (`UTC`, `Europe/Berlin`, …) or remove the variable entirely.

Placed it on the Flows triggers page rather than the Cache/Config env-var tables because that's where users configure schedules and it's the closest surface to the feature that triggers the error.
