### PR TITLE
docs: list the IAM permissions the SES email transport needs

### DIFF
--- a/content/configuration/email.md
+++ b/content/configuration/email.md
@@ -50,6 +50,42 @@ Based on the `EMAIL_TRANSPORT` used, you must also provide additional variables.
 | `EMAIL_SES_CREDENTIALS__SECRET_ACCESS_KEY` | Your AWS SES secret key.    |               |
 | `EMAIL_SES_REGION`                         | Your AWS SES region.        |               |
 
+#### Required IAM Permissions
+
+The IAM user or role whose credentials you use above needs permission to send raw emails and to query account-level
+sending state for the `/server/health` check. A minimal policy looks like this:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DirectusSesSend",
+      "Effect": "Allow",
+      "Action": "ses:SendRawEmail",
+      "Resource": [
+        "arn:aws:ses:<region>:<account-id>:identity/<your-verified-sender-domain-or-address>"
+      ]
+    },
+    {
+      "Sid": "DirectusSesHealthCheck",
+      "Effect": "Allow",
+      "Action": "ses:GetAccount",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+- `ses:SendRawEmail` is the action the SES transport invokes to deliver every outbound message. Scope the resource to the
+  sender identities (domain or email address) you will send from in `EMAIL_FROM`.
+- `ses:GetAccount` is called by the `/server/health` endpoint's email probe. Without it the probe emits an opaque
+  `Converting circular structure to JSON` error even though email delivery otherwise works. `ses:GetAccount` does not
+  support resource-level permissions and must be granted on `*`.
+
+If you set a sender identity that lives in a different SES region from `EMAIL_SES_REGION`, include the identity ARN for
+that region as well.
+
 ## Email Templates
 
 Templates can be used to add custom templates for your emails, or to override the system emails used for things like resetting a password or inviting a user.


### PR DESCRIPTION
Closes #618.

The `EMAIL_TRANSPORT=ses` configuration page currently only lists the three env variables (`EMAIL_SES_CREDENTIALS__ACCESS_KEY_ID`, `…__SECRET_ACCESS_KEY`, `EMAIL_SES_REGION`), leaving operators to trial-and-error their way to the right IAM policy. The reporter walked that path and documented the exact set of actions in the issue — and specifically called out that without `ses:GetAccount` the `/server/health` endpoint reports a confusing `Converting circular structure to JSON` error while email delivery itself still works.

This PR adds a new **Required IAM Permissions** subsection under **AWS SES** with:

- A minimal, least-privilege `Version: 2012-10-17` policy snippet.
- `ses:SendRawEmail`, scoped to the sender identity ARN (so operators can narrow it to the `EMAIL_FROM` domain or address rather than granting `*`).
- `ses:GetAccount`, called by the `/server/health` email probe. Callout that it doesn't support resource-level permissions and has to live on `*`.
- A note for people running a sender identity in a different region from `EMAIL_SES_REGION`.

Everything else on the page is untouched.
