### PR TITLE
Add STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL to docs

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -21,11 +21,12 @@ In the Data Studio, files will automatically be uploaded to the first configured
 
 For each of the storage locations listed, you must provide the following configuration (variable name must be uppercase in these options):
 
-| Variable                                   | Description                                                                          | Default Value |
-| ------------------------------------------ | ------------------------------------------------------------------------------------ | ------------- |
-| `STORAGE_<LOCATION>_DRIVER`                | Which driver to use, either `local`, `s3`, `gcs`, `azure`, `cloudinary`, `supabase`. |               |
-| `STORAGE_<LOCATION>_ROOT`                  | Where to store the files on disk.                                                    | `''`          |
-| `STORAGE_<LOCATION>_HEALTHCHECK_THRESHOLD` | Healthcheck timeout threshold in ms.                                                 | `750`         |
+| Variable                                        | Description                                                                                                                                                                                                                                      | Default Value |
+|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------- |
+| `STORAGE_<LOCATION>_DRIVER`                     | Which driver to use, either `local`, `s3`, `gcs`, `azure`, `cloudinary`, `supabase`.                                                                                                                                                             |               |
+| `STORAGE_<LOCATION>_ROOT`                       | Where to store the files on disk.                                                                                                                                                                                                                | `''`          |
+| `STORAGE_<LOCATION>_HEALTHCHECK_THRESHOLD`      | Healthcheck timeout threshold in ms.                                                                                                                                                                                                             | `750`         |
+| `STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL` | Interval in ms between full write (`PUT`) checks. Within the interval, only a lightweight `GET` is performed on the existing health-check file. If the `GET` fails, a new `PUT` is triggered immediately. Set to `0` to disable (always writes). | `0`           |
 
 Based on your configured drivers, you must also provide additional variables, where `<LOCATION>` is the capitalized name of the item in the `STORAGE_LOCATIONS` value.
 


### PR DESCRIPTION
## Add `STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL` environment variable documentation

### Summary
Documents the new optional environment variable `STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL`. This variable allows users to throttle health‑check write operations (`PUT`) to cloud storage backends (like S3), dramatically reducing the number of `PUT` requests and helping stay within free‑tier limits.

### Related PR
_Link to the corresponding PR in the main Directus repository (once created)._

### Changes
- Added a row to the `Storage` configuration describing the new variable, its behaviour, and its default value (`0` – meaning always write).
- Clarified that the health check reads the existing health‑check file (`GET`) during the interval, and only performs a full write (`PUT`) when the interval expires or the read fails.
- Provided guidance that setting the variable to a non‑zero value (e.g. `60000` for one minute) significantly cuts `PUT` operations while still reliably monitoring storage health.

### Checklist
- [x] Variable name matches the implementation
- [x] Description accurately reflects the throttling and fallback logic
- [x] Default value documented
- [ ] Awaiting merge of the main Directus PR (or PR number for cross‑reference)
