### PR TITLE
Adjust messaging for custom domains and env vars

### DIFF
--- a/content/cloud/3.configuration/1.custom-domains.md
+++ b/content/cloud/3.configuration/1.custom-domains.md
@@ -1,32 +1,10 @@
 ---
 title: Custom Domains
-description: Learn how to set up a custom domain for your Directus Enterprise Cloud project.
+description: Custom domains are available for your Directus Enterprise Cloud project.
 ---
 
-<!-- TODO: Image -->
-
-Directus provides its own `<project-name>.directus.app` domain by default, but you can set your own domain for accessing your project.
+Directus provides its own `<project-name>.directus.app` domain by default for all Cloud Projects. Setting a custom domain is only available for Enterprise projects by reaching out to our support team.
 
 ::callout{icon="material-symbols:info-outline"}
-Setting a custom domain is only available for enterprise projects. [Contact us](https://directus.io/contact) to get started with enterprise projects.
+[Contact&nbsp;us](https://directus.io/contact) to get started with an Enterprise project or to request a custom domain.
 ::
-
-## Set a Custom Domain
-
-Open your project's settings from the cloud dashboard. You will see your assigned `directus.app` domain.
-
-By clicking on "Add Custom Domain", you can then enter your new domain. 
-
-::callout{icon="material-symbols:info-outline"}
-Custom domains must contain the format of `subdomain.your-custom-domain.tld`. You cannot use `directus` as a custom host domain.
-::
-
-Once set, you'll be prompted to enter a CNAME record for your DNS provider. Once that's done, and the changes have gone through, you'll receive an email from us confirming the custom domain has been set up.
-
-::callout{icon="material-symbols:info-outline"}
-You can only have one custom domain at a time. If you wish to change it, you'll have to remove it and set a new one.
-::
-
-## Remove a Custom Domain
-
-Removing your custom domain is done by clicking on :icon{name="material-symbols:delete-outline-sharp"} next to it, and typing its name to confirm.

--- a/content/cloud/3.configuration/2.environment-variables.md
+++ b/content/cloud/3.configuration/2.environment-variables.md
@@ -5,6 +5,10 @@ description: Learn about environment variables in Directus Cloud.
 
 You can configure your Directus project using a number of environment variable presets which can be configured in the Cloud dashboard.
 
+::callout{icon="material-symbols:info-outline"}
+Directus Cloud Enterprise customers are able to customize a wider variety of environment variables. Enterprise customers should [contact&nbsp;support](https://directus.io/contact) for help with updating their environment variables.
+::
+
 ![Cloud dashboard project configuration screen showing a number of configurable settings such as CORS and maximum file upload size.](/img/363335e4-59bb-4233-bca5-94bb1f39f3fd.webp)
 
 ::callout{icon="material-symbols:info-outline"}
@@ -17,26 +21,26 @@ While the Cloud dashboard provides configuration via a UI with some preset optio
 
 ### Files
 
-* `FILES_MAX_UPLOAD_SIZE` 
+- `FILES_MAX_UPLOAD_SIZE`
 
 [Read more about Upload Limit environment variables.](/configuration/files)
 
 ### Security & Limits
 
-* `PASSWORD_RESET_URL_ALLOW_LIST`
-* `USER_INVITE_URL_ALLOW_LIST`
-* `USER_REGISTER_URL_ALLOW_LIST`
+- `PASSWORD_RESET_URL_ALLOW_LIST`
+- `USER_INVITE_URL_ALLOW_LIST`
+- `USER_REGISTER_URL_ALLOW_LIST`
 
 [Read more about Security environment variables.](/configuration/security-limits)
 
 ### CORS
 
-* `CORS_ENABLED` 
-* `CORS_ORIGIN`
-* `CORS_METHODS`
-* `CORS_ALLOWED_HEADERS` 
-* `CORS_EXPOSED_HEADERS`
-* `CORS_CREDENTIALS` 
-* `CORS_MAX_AGE`
+- `CORS_ENABLED`
+- `CORS_ORIGIN`
+- `CORS_METHODS`
+- `CORS_ALLOWED_HEADERS`
+- `CORS_EXPOSED_HEADERS`
+- `CORS_CREDENTIALS`
+- `CORS_MAX_AGE`
 
 [Read more about CORS environment variables.](/configuration/security-limits)


### PR DESCRIPTION
Self service custom domains have been temporarily disabled and so the docs should reflect this.

So too have self-service env vars through the Cloud dashboard for enterprise tier.