### PR TITLE
Document visual-editor customization vars for editable-element redesign

### DIFF
--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -26,8 +26,6 @@ Read more: https://www.tiny.cloud/docs/tinymce/6/tinymce-and-screenreaders/
 
 ### Things to keep in mind
 
-- Visual Editor is only accessible on the Directus side — not your website. So we always need to click an edit button first, then the
-  overlays are accessible.
 - Manual Sorting is currently not supported/accessible.
 - Once focused, the code interface (Codemirror) cannot be exited using the tab key.
 - The Markdown interface also doesn’t allow you to exit the field. This is because it supports tabs inside the editor’s

--- a/content/guides/02.content/8.visual-editor/3.customization.md
+++ b/content/guides/02.content/8.visual-editor/3.customization.md
@@ -39,6 +39,9 @@ The library ships with a number of built in CSS Selectors already applied to its
 .directus-visual-editing-edit-button {
 	/* the edit button */
 }
+.directus-visual-editing-actions-flipped {
+	/* a modifier on the rect that flips the action buttons below it, applied automatically when the rect is near the top of the viewport */
+}
 ```
 
 ## CSS Variables
@@ -48,20 +51,32 @@ The library also ships with a number of predefined CSS variables. These can be o
 ```css
 :root {
 	--directus-visual-editing--overlay--z-index: 999999999;
-	--directus-visual-editing--rect--border-spacing: 9px;
-	--directus-visual-editing--rect--border-width: 2px;
+	--directus-visual-editing--rect--border-spacing: 8px;
+	--directus-visual-editing--rect--border-width: 1px;
 	--directus-visual-editing--rect--border-color: #6644ff;
 	--directus-visual-editing--rect--border-radius: 6px;
-	--directus-visual-editing--rect-hover--opacity: 0.333;
-	--directus-visual-editing--rect-highlight--opacity: 0.333;
-	--directus-visual-editing--edit-btn--width: 28px;
-	--directus-visual-editing--edit-btn--height: 28px;
-	--directus-visual-editing--edit-btn--radius: 50%;
+	--directus-visual-editing--rect-hover--opacity: 0.4;
+	--directus-visual-editing--rect-highlight--opacity: 0.4;
+	--directus-visual-editing--actions--offset: 4px;
+	--directus-visual-editing--actions--focus-ring-color: #6644ff;
+	--directus-visual-editing--actions--focus-ring-width: 2px;
+	--directus-visual-editing--actions--focus-ring-offset: 2px;
+	--directus-visual-editing--edit-btn--width: 24px;
+	--directus-visual-editing--edit-btn--height: 24px;
+	--directus-visual-editing--edit-btn--radius: 6px;
 	--directus-visual-editing--edit-btn--bg-color: #6644ff;
+	--directus-visual-editing--edit-btn-hover--bg-color: color-mix(in srgb, #6644ff, #2e3C43 25%);
 	--directus-visual-editing--edit-btn--icon-bg-image: url('data:image/svg+xml,<svg>…</svg>');
 	--directus-visual-editing--edit-btn--icon-bg-size: 66.6%;
+	--directus-visual-editing--ai-btn--bg-color: #6644ff;
+	--directus-visual-editing--ai-btn-hover--bg-color: color-mix(in srgb, #6644ff, #2e3C43 25%);
 }
 ```
+
+::callout{icon="material-symbols:info-outline"}
+**Defaults inside the Directus Studio**
+When the visual editor runs inside the Directus Studio iframe, defaults for several variables are sourced from the active Studio theme (primary color, border radius, button size, focus-ring width/offset) rather than the compiled-in fallbacks shown above. Your own `:root` or `customClass` overrides still take precedence.
+::
 
 ## Custom Classes
 


### PR DESCRIPTION
## Summary

Sub-PR for #628. Documents the consumer-facing CSS surface introduced by the editable-element overlay redesign in [`directus/directus`](https://github.com/directus/directus) (branch `florian/cms-1944-update-editable-elements-design-in-visual-editor-library`).

Files touched:
- `content/guides/02.content/8.visual-editor/3.customization.md` — main change: new CSS surface + Studio-theme callout.
- `content/getting-started/10.accessibility.md` — drops the now-obsolete "Visual Editor is only accessible on the Directus side" bullet. The redesign adds `:focus-visible` styling and `:focus-within` reveal to the overlay buttons, so they're keyboard-reachable on the website.

### What changed

**New CSS selector**
- `.directus-visual-editing-actions-flipped` — modifier on the rect that flips the action buttons below it when the rect sits near the top of the viewport.

**New CSS variables**
- `--directus-visual-editing--actions--offset`
- `--directus-visual-editing--actions--focus-ring-color` / `--focus-ring-width` / `--focus-ring-offset`
- `--directus-visual-editing--edit-btn-hover--bg-color`
- `--directus-visual-editing--ai-btn--bg-color` / `--ai-btn-hover--bg-color`

**Refreshed compiled-in defaults** to match the redesigned overlay:
- `border-spacing` 9px → 8px
- `border-width` 2px → 1px
- `rect-hover--opacity` / `rect-highlight--opacity` 0.333 → 0.4
- `edit-btn--width` / `--height` 28px → 24px
- `edit-btn--radius` 50% → 6px (circle → rounded square)

**New callout** explaining that inside the Studio iframe these defaults are sourced from the active Studio theme (primary color, border radius, button size, focus-ring width/offset). User `:root` / `customClass` overrides still take precedence.