### PR TITLE
Revert visual-editor overlay defaults: border-width 2px, hover/highlight opacity 0.333

### DIFF
--- a/content/guides/02.content/8.visual-editor/3.customization.md
+++ b/content/guides/02.content/8.visual-editor/3.customization.md
@@ -52,11 +52,11 @@ The library also ships with a number of predefined CSS variables. These can be o
 :root {
 	--directus-visual-editing--overlay--z-index: 999999999;
 	--directus-visual-editing--rect--border-spacing: 8px;
-	--directus-visual-editing--rect--border-width: 1px;
+	--directus-visual-editing--rect--border-width: 2px;
 	--directus-visual-editing--rect--border-color: #6644ff;
 	--directus-visual-editing--rect--border-radius: 6px;
-	--directus-visual-editing--rect-hover--opacity: 0.4;
-	--directus-visual-editing--rect-highlight--opacity: 0.4;
+	--directus-visual-editing--rect-hover--opacity: 0.333;
+	--directus-visual-editing--rect-highlight--opacity: 0.333;
 	--directus-visual-editing--actions--offset: 4px;
 	--directus-visual-editing--actions--focus-ring-color: #6644ff;
 	--directus-visual-editing--actions--focus-ring-width: 2px;


### PR DESCRIPTION
Sub-PR for #628.

Reflects directus@cda18ff874 ("use focus-ring-width instead of borderWidth theme token and revert opacity values"), which:

- Removed the `borderWidth` field from `VisualEditingTheme`. The compiled-in fallback for `--directus-visual-editing--rect--border-width` is now sourced from `t.focusRingWidth` (default `2px`) instead of the removed `t.borderWidth` (was `1px`).
- Reverted the default `--hover-opacity` from `0.4` back to `0.333`.
- Reverted the default `--directus-visual-editing--rect-highlight--opacity` from `0.4` back to `0.333`.

## Changes

- `content/guides/02.content/8.visual-editor/3.customization.md`
  - `--directus-visual-editing--rect--border-width: 1px;` → `2px`
  - `--directus-visual-editing--rect-hover--opacity: 0.4;` → `0.333`
  - `--directus-visual-editing--rect-highlight--opacity: 0.4;` → `0.333`

The Studio-defaults callout still reads correctly: it already lists "focus-ring width/offset" as Studio-sourced, which transitively covers the new rect border-width fallback.