### PR TITLE
Fix docs MCP URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ DIRECTUS_URL=https://marketing-directus-url.com
 GOOGLE_TAG_MANAGER_ID=GTM-PTLT3GH
 POSTHOG_API_HOST=https://directus.io/ingest
 POSTHOG_API_KEY=phc_secret_key_here
-NUXT_PUBLIC_SITE_URL=https://directus.io
+NUXT_PUBLIC_SITE_URL=https://directus.com
 # Optional. Fine-grained PAT, public repos read-only. Required for code search and raises GitHub raw rate limits.
 # GITHUB_TOKEN=github_pat_...

--- a/content/mcp-help.md
+++ b/content/mcp-help.md
@@ -13,7 +13,7 @@ This is the **docs MCP server**, which exposes this documentation site to AI cli
 ## Server URL
 
 ```
-https://directus.io/docs/mcp
+https://directus.com/docs/mcp
 ```
 
 Transport: streamable HTTP. No authentication required.
@@ -39,7 +39,7 @@ For clients without a one-click installer, add the server to your MCP config.
 ### Claude Code
 
 ```bash
-claude mcp add --transport http directus-docs https://directus.io/docs/mcp
+claude mcp add --transport http directus-docs https://directus.com/docs/mcp
 ```
 
 ### Claude Desktop
@@ -51,7 +51,7 @@ Edit `claude_desktop_config.json`:
   "mcpServers": {
     "directus-docs": {
       "type": "http",
-      "url": "https://directus.io/docs/mcp"
+      "url": "https://directus.com/docs/mcp"
     }
   }
 }
@@ -59,7 +59,7 @@ Edit `claude_desktop_config.json`:
 
 ### Codex / Windsurf / other HTTP-MCP clients
 
-Point them at `https://directus.io/docs/mcp` with transport set to `http` (sometimes called `streamable-http`).
+Point them at `https://directus.com/docs/mcp` with transport set to `http` (sometimes called `streamable-http`).
 
 ## Available tools
 
@@ -84,7 +84,7 @@ The assistant should call `search-docs` or `list-docs`, then `get-doc` to read t
 
 ## Troubleshooting
 
-- **Connection refused or 404** - confirm the URL is exactly `https://directus.io/docs/mcp` (note the `/docs` prefix).
+- **Connection refused or 404** - confirm the URL is exactly `https://directus.com/docs/mcp` (note the `/docs` prefix).
 - **Tools not showing up** - restart your MCP client after adding the server. Some clients only load tools at startup.
 - **Search returns nothing** - `search-docs` is case-insensitive but does keyword match. Try fewer or broader terms.
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -131,6 +131,7 @@ export default defineNuxtConfig({
 			typesenseUrl: process.env.TYPESENSE_URL,
 			typesensePublicApiKey: process.env.TYPESENSE_PUBLIC_API_KEY,
 			typesenseCollection,
+			siteUrl: process.env.NUXT_PUBLIC_SITE_URL,
 		},
 		directusUrl: process.env.DIRECTUS_URL,
 	},

--- a/server/mcp/tools/get-doc.ts
+++ b/server/mcp/tools/get-doc.ts
@@ -3,7 +3,6 @@ import { queryCollection } from '@nuxt/content/server';
 import { useEvent } from 'nitropack/runtime';
 import { z } from 'zod';
 
-const SITE_ORIGIN = 'https://directus.io';
 const BASE_PATH = '/docs';
 
 export default defineMcpTool({
@@ -19,6 +18,8 @@ export default defineMcpTool({
 	cache: '10m',
 	handler: async ({ path }) => {
 		const event = useEvent();
+		const config = useRuntimeConfig();
+		const siteOrigin = config.public.siteUrl.replace(/\/$/, '');
 		const normalized = path.startsWith('/') ? path : `/${path}`;
 
 		const page = await queryCollection(event, 'content')
@@ -34,7 +35,7 @@ export default defineMcpTool({
 			path: page.path,
 			description: page.description ?? '',
 			content: page.rawbody ?? '',
-			url: `${SITE_ORIGIN}${BASE_PATH}${page.path}`,
+			url: `${siteOrigin}${BASE_PATH}${page.path}`,
 		};
 	},
 });

--- a/server/mcp/tools/list-docs.ts
+++ b/server/mcp/tools/list-docs.ts
@@ -4,7 +4,6 @@ import { useEvent } from 'nitropack/runtime';
 import { z } from 'zod';
 import { docsSections } from '#shared/utils/docsSections';
 
-const SITE_ORIGIN = 'https://directus.io';
 const BASE_PATH = '/docs';
 
 const allPrefixes = Array.from(new Set(docsSections.flatMap(s => s.prefixes))).sort();
@@ -26,6 +25,8 @@ export default defineMcpTool({
 	cache: '10m',
 	handler: async ({ pathPrefix, limit }) => {
 		const event = useEvent();
+		const config = useRuntimeConfig();
+		const siteOrigin = config.public.siteUrl.replace(/\/$/, '');
 		let query = queryCollection(event, 'content')
 			.where('path', 'NOT LIKE', '%/.%')
 			.where('path', 'NOT LIKE', '%/_partials/%')
@@ -41,7 +42,7 @@ export default defineMcpTool({
 			title: row.title,
 			path: row.path,
 			description: row.description ?? '',
-			url: `${SITE_ORIGIN}${BASE_PATH}${row.path}`,
+			url: `${siteOrigin}${BASE_PATH}${row.path}`,
 		}));
 	},
 });

--- a/server/mcp/tools/search-docs.ts
+++ b/server/mcp/tools/search-docs.ts
@@ -5,7 +5,6 @@ import { docsSections } from '#shared/utils/docsSections';
 import { frameworks } from '#shared/utils/frameworks';
 import { parseTypesenseUrl } from '#shared/utils/parseTypesenseUrl';
 
-const SITE_ORIGIN = 'https://directus.io';
 const BASE_PATH = '/docs';
 
 const sectionIds = docsSections.map(s => s.id) as [string, ...string[]];
@@ -50,6 +49,7 @@ export default defineMcpTool({
 	cache: '5m',
 	handler: async ({ query, section, framework, limit }) => {
 		const config = useRuntimeConfig();
+		const siteOrigin = config.public.siteUrl.replace(/\/$/, '');
 
 		if (!config.public.typesenseUrl || !config.public.typesensePublicApiKey || !config.public.typesenseCollection) {
 			throw createError({ statusCode: 503, message: 'Search backend not configured' });
@@ -93,7 +93,7 @@ export default defineMcpTool({
 			const rawUrl = doc.url || `${docPath}${doc.anchor ? `#${doc.anchor}` : ''}`;
 			const url = rawUrl.startsWith('http')
 				? rawUrl
-				: `${SITE_ORIGIN}${rawUrl.startsWith('/') ? '' : BASE_PATH}${rawUrl}`;
+				: `${siteOrigin}${rawUrl.startsWith('/') ? '' : BASE_PATH}${rawUrl}`;
 			return {
 				title: doc.search_title || doc.title || '',
 				heading: doc.heading,


### PR DESCRIPTION
## Changes

- Exposes `NUXT_PUBLIC_SITE_URL` as public Nuxt runtime config.
- Uses that runtime config value when MCP tools build docs URLs.
- Updates docs MCP setup examples and `.env.example` to use `https://directus.com`.

## Potential Risks

- `NUXT_PUBLIC_SITE_URL` must be set where the docs app is deployed.

## Review Notes

- Push hook ran `pnpm redirects:check`; typecheck not run because dependencies are not installed locally.