### PR TITLE
Fix licensing overview redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -7,10 +7,6 @@
     "to": "/guides/ai",
     "statusCode": 301
   },
-  "/licensing/overview": {
-    "to": "/configuration/general#license",
-    "statusCode": 301
-  },
   "/releases/breaking-changes/version-12": {
     "to": "/releases/breaking-changes",
     "statusCode": 301


### PR DESCRIPTION
## Changes

- Removed the stale `/licensing/overview` redirect to `/configuration/general#license`.
- Lets the licensing overview route resolve to its actual docs page.

## Potential Risks

- None expected; this only removes a redirect that conflicts with an existing page.