### PR TITLE
Fix docs MCP browser redirect

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -398,7 +398,7 @@ export default defineNuxtConfig({
 	mcp: {
 		name: 'Directus documentation',
 		description: 'Search and read the Directus documentation.',
-		browserRedirect: '/mcp-help',
+		browserRedirect: `${BASE_URL}/mcp-help`,
 	},
 
 	ogImage: { zeroRuntime: true },


### PR DESCRIPTION
## Changes

- Updates the docs MCP browser redirect to include the Nuxt base path.
- Browser requests to the docs MCP endpoint now redirect to `/docs/mcp-help` instead of root `/mcp-help`.

## Potential Risks

- Low; this only affects browser fallback redirect behavior for the docs MCP endpoint.

## Review Notes

- PR 692 handled the domain change; this fixes the missed base-path redirect.