### PR TITLE
Fix docs MCP URLs

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -398,7 +398,7 @@ export default defineNuxtConfig({
 	mcp: {
 		name: 'Directus documentation',
 		description: 'Search and read the Directus documentation.',
-		browserRedirect: '/mcp-help',
+		browserRedirect: `${BASE_URL}/mcp-help`,
 	},
 
 	ogImage: { zeroRuntime: true },


### PR DESCRIPTION
## Changes

- Exposes `NUXT_PUBLIC_SITE_URL` as public Nuxt runtime config.
- Uses that runtime config value when MCP tools build docs URLs.
- Updates docs MCP setup examples and `.env.example` to use `https://directus.com`.

## Potential Risks

- `NUXT_PUBLIC_SITE_URL` must be set where the docs app is deployed.

## Review Notes

- Push hook ran `pnpm redirects:check`; typecheck not run because dependencies are not installed locally.