### PR TITLE
Fix inline personalization SSR state

### DIFF
--- a/app/components/InlinePersonalize.vue
+++ b/app/components/InlinePersonalize.vue
@@ -64,7 +64,7 @@ const optionBase = 'inline-flex min-w-0 cursor-pointer items-center gap-2 rounde
 </script>
 
 <template>
-	<div class="relative rounded-xl border border-default bg-default px-4 py-4">
+	<div class="relative w-full max-w-full overflow-hidden rounded-xl border border-default bg-default px-4 py-4">
 		<Transition
 			mode="out-in"
 			enter-active-class="transition-opacity duration-200"
@@ -76,7 +76,7 @@ const optionBase = 'inline-flex min-w-0 cursor-pointer items-center gap-2 rounde
 				v-if="phase === 'asking'"
 				key="asking"
 			>
-				<header class="mb-3.5 flex items-start justify-between gap-3">
+				<header class="mb-3.5 flex flex-col gap-3 @min-[28rem]/docs-pane:flex-row @min-[28rem]/docs-pane:items-start @min-[28rem]/docs-pane:justify-between">
 					<div class="min-w-0">
 						<DocsEyebrow class="mb-1">
 							Personalize
@@ -85,7 +85,7 @@ const optionBase = 'inline-flex min-w-0 cursor-pointer items-center gap-2 rounde
 							{{ currentTitle }}
 						</h3>
 					</div>
-					<div class="flex shrink-0 items-center gap-2">
+					<div class="flex shrink-0 items-center justify-between gap-2 @min-[28rem]/docs-pane:justify-start">
 						<span class="font-mono text-xs text-muted">{{ stepIndex + 1 }} of {{ stepKeys.length }}</span>
 						<UButton
 							label="Skip"
@@ -116,7 +116,7 @@ const optionBase = 'inline-flex min-w-0 cursor-pointer items-center gap-2 rounde
 								placeholder="Search frameworks..."
 								class="w-full mb-2"
 							/>
-							<div class="grid max-h-60 grid-cols-2 gap-1.5 overflow-y-auto @min-[32rem]/docs-pane:grid-cols-3">
+							<div class="grid max-h-60 grid-cols-1 gap-1.5 overflow-y-auto @min-[28rem]/docs-pane:grid-cols-2 @min-[44rem]/docs-pane:grid-cols-3">
 								<button
 									v-for="f in filteredFrameworks"
 									:key="f.slug"
@@ -140,7 +140,7 @@ const optionBase = 'inline-flex min-w-0 cursor-pointer items-center gap-2 rounde
 						</template>
 
 						<template v-else-if="currentKey === 'useCase'">
-							<div class="grid grid-cols-2 gap-1.5 @min-[32rem]/docs-pane:grid-cols-3">
+							<div class="grid grid-cols-1 gap-1.5 @min-[28rem]/docs-pane:grid-cols-2 @min-[44rem]/docs-pane:grid-cols-3">
 								<button
 									v-for="u in useCases"
 									:key="u.slug"
@@ -158,7 +158,7 @@ const optionBase = 'inline-flex min-w-0 cursor-pointer items-center gap-2 rounde
 						</template>
 
 						<template v-else>
-							<div class="grid grid-cols-1 gap-1.5 @min-[32rem]/docs-pane:grid-cols-3">
+							<div class="grid grid-cols-1 gap-1.5 @min-[44rem]/docs-pane:grid-cols-3">
 								<button
 									v-for="e in experiences"
 									:key="e.slug"

--- a/app/composables/useUserPreferences.ts
+++ b/app/composables/useUserPreferences.ts
@@ -29,6 +29,7 @@ export default function useUserPreferences() {
 		sameSite: 'lax',
 		path: '/',
 	});
+	const activeOnboarding = useState('directus-docs-onboarding-active', () => false);
 
 	const legacyFramework = useCookie<string | null>(LEGACY_FRAMEWORK_COOKIE);
 	if (!cookie.value.framework && legacyFramework.value) {
@@ -36,7 +37,11 @@ export default function useUserPreferences() {
 		if (valid) cookie.value = { ...cookie.value, framework: valid.slug };
 	}
 
-	const prefs = computed<UserPreferences>(() => ({ ...defaultPrefs, ...cookie.value }));
+	const prefs = computed<UserPreferences>(() => {
+		const value = { ...defaultPrefs, ...cookie.value };
+		if (value.onboarding === 'active') value.onboarding = null;
+		return value;
+	});
 
 	function set<K extends PreferenceKey>(key: K, value: UserPreferences[K] | null) {
 		const validated = value === null ? null : validators[key](value as string);
@@ -47,9 +52,12 @@ export default function useUserPreferences() {
 
 	function reset() {
 		cookie.value = { ...defaultPrefs };
+		activeOnboarding.value = false;
 		library.value = null;
 		if (import.meta.client) {
-			try { localStorage.removeItem(API_CONSUMER_LS_KEY); }
+			try {
+				localStorage.removeItem(API_CONSUMER_LS_KEY);
+			}
 			catch { /* ignore */ }
 		}
 	}
@@ -69,16 +77,19 @@ export default function useUserPreferences() {
 	));
 
 	const onboardingState = computed<OnboardingState>(() => {
+		if (activeOnboarding.value) return 'active';
 		const v = prefs.value.onboarding;
 		if (v) return v;
 		return hasAnyPref.value ? 'onboarded' : 'idle';
 	});
 
-	function setOnboarding(state: OnboardingState) {
+	function setOnboarding(state: Exclude<OnboardingState, 'active'>) {
+		activeOnboarding.value = false;
 		cookie.value = { ...prefs.value, onboarding: state };
 	}
 	function startOnboarding() {
-		setOnboarding('active');
+		activeOnboarding.value = true;
+		cookie.value = { ...prefs.value, onboarding: null };
 	}
 	function completeOnboarding() {
 		setOnboarding('onboarded');
@@ -92,7 +103,9 @@ export default function useUserPreferences() {
 	}
 
 	if (import.meta.client && library.value === null) {
-		try { library.value = localStorage.getItem(API_CONSUMER_LS_KEY); }
+		try {
+			library.value = localStorage.getItem(API_CONSUMER_LS_KEY);
+		}
 		catch { /* ignore */ }
 	}
 	function setLibrary(value: string | null) {


### PR DESCRIPTION
## Changes

- Keeps active personalization onboarding in Nuxt state instead of the SSR-readable preferences cookie.
- Treats stale `onboarding: active` cookie values as unset so SSR does not render the inline wizard above the home hero.
- Hardens the inline personalization layout for narrow docs panes with stacked headers, overflow guards, and safer grid breakpoints.

## Potential Risks

- Reloading mid-onboarding now returns to the idle CTA instead of resuming the active wizard.

## Review Notes

- Targeted ESLint and whitespace checks pass; full `vue-tsc` still fails on existing unrelated repo errors.