### PR TITLE
Move configuration to own subnav section

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -161,12 +161,11 @@ export default defineAppConfig({
 						to: '/self-hosting/overview',
 						icon: 'material-symbols:dns-outline',
 					},
-					{
-						label: 'Configuration',
-						to: '/configuration/intro',
-						icon: 'material-symbols:settings-outline',
-					},
 				],
+			},
+			{
+				label: 'Configuration',
+				to: '/configuration/intro',
 			},
 			{
 				label: 'Resources',

--- a/shared/utils/docsSections.ts
+++ b/shared/utils/docsSections.ts
@@ -2,6 +2,7 @@ export type DocsSectionId
 	= | 'getting-started'
 		| 'guides'
 		| 'deploy'
+		| 'configuration'
 		| 'tutorials'
 		| 'frameworks'
 		| 'reference'
@@ -45,8 +46,15 @@ export const docsSections: DocsSection[] = [
 		id: 'deploy',
 		label: 'Hosting',
 		to: '/cloud/getting-started/introduction',
-		prefixes: ['/cloud', '/self-hosting', '/configuration'],
+		prefixes: ['/cloud', '/self-hosting'],
 		icon: 'material-symbols:cloud-outline',
+	},
+	{
+		id: 'configuration',
+		label: 'Configuration',
+		to: '/configuration/intro',
+		prefixes: ['/configuration'],
+		icon: 'material-symbols:settings-outline',
 	},
 	{
 		id: 'frameworks',
@@ -91,7 +99,7 @@ export const docsGroups: DocsGroup[] = [
 		label: 'Docs',
 		to: '/getting-started/overview',
 		icon: 'material-symbols:menu-book-outline',
-		sectionIds: ['getting-started', 'guides', 'deploy', 'frameworks', 'community'],
+		sectionIds: ['getting-started', 'guides', 'deploy', 'configuration', 'frameworks', 'community'],
 	},
 	{
 		id: 'reference',


### PR DESCRIPTION
## Changes

- Moves Configuration out of Hosting and into its own docs sub-nav section.
- Keeps Hosting scoped to Cloud and Self-Hosting routes.

## Potential Risks

- None expected; this only changes nav grouping.

## Review Notes

- Smoke checked `/docs/configuration/intro` and `/docs/self-hosting/overview` locally.