### PR TITLE
Bump prerender concurrency to 3

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -194,7 +194,7 @@ export default defineNuxtConfig({
 			routes: ['/', `${BASE_URL}/api`, ...docsApiReferencePrerenderRoutes],
 			crawlLinks: true,
 			ignore: [/^\/docs\/mcp\/deeplink(\?.*)?$/],
-			concurrency: 1,
+			concurrency: 3,
 			retry: 2,
 			retryDelay: 1000,
 		},


### PR DESCRIPTION
## What

Bumps Nitro prerender `concurrency` from `1` to `3` to speed up builds.

## Why

`concurrency: 1` was set to keep peak memory under the Vercel build ceiling back when per-route API-reference rendering (Shiki highlighting + large OAS payloads) was OOM-killing the build. The pre-render precompute work (#708) moved that expensive highlighting to a build-time step, making each route render much lighter — so parallel renders should now fit comfortably.

This is a test to see how far we can push concurrency without OOMing. Starting conservative at 3.

## Verification

- `pnpm build` completes clean locally with `concurrency: 3` — no OOM, no `ENOTDIR`.
- 430 pages prerendered, including `/api` index + all per-tag reference pages.
- `api/` output is a proper directory (index + per-tag subdirs), no payload-cache file/dir collision.

## Watch on deploy

Vercel build memory. If it OOMs, revert this single commit; if it's clean with headroom, we can try higher.