### PR TITLE
Shrink docs nav icons

### DIFF
--- a/app/components/DocsHeader.vue
+++ b/app/components/DocsHeader.vue
@@ -29,10 +29,8 @@ const groupItems = computed(() =>
 
 				class="hidden @min-[40rem]/docs-pane:flex"
 				:ui="{
-					// list: 'flex items-center gap-2 rounded-full ring ring-inset ring-accented bg-elevated p-0.5',
-					// item: 'py-0',
-					// link: 'rounded-full px-3 py-1 text-base before:rounded-full before:inset-0 data-[active]:before:bg-transparent! aria-[current=page]:before:bg-transparent!',
-					// linkLeadingIcon: 'size-4',
+					linkLeadingIcon: 'size-4',
+					linkTrailingIcon: 'size-4',
 				}"
 			/>
 		</template>
@@ -80,7 +78,7 @@ const groupItems = computed(() =>
 						:class="active ? 'text-primary font-medium' : 'text-muted'"
 			
 					>
-						<UIcon v-if="link.icon" :name="link.icon" class="size-5 shrink-0" />
+						<UIcon v-if="link.icon" :name="link.icon" class="size-4 shrink-0" />
 						{{ link.title }}
 					</span>
 					<span
@@ -89,7 +87,7 @@ const groupItems = computed(() =>
 						:class="active ? 'text-primary' : 'text-highlighted'"
 			
 					>
-						<UIcon v-if="link.icon" :name="link.icon" class="size-5 shrink-0" />
+						<UIcon v-if="link.icon" :name="link.icon" class="size-4 shrink-0" />
 						{{ link.title }}
 					</span>
 				</template>

--- a/app/components/DocsSubNav.vue
+++ b/app/components/DocsSubNav.vue
@@ -21,6 +21,10 @@ defineProps<{
 				:items="items"
 				orientation="horizontal"
 				variant="link"
+				:ui="{
+					linkLeadingIcon: 'size-4',
+					linkTrailingIcon: 'size-4',
+				}"
 			/>
 			<SettingsDrawerTrigger show-label />
 		</UContainer>


### PR DESCRIPTION
## Changes

- Shrinks docs header and sub-nav navigation icons only.
- Keeps nav text, buttons, spacing, and row heights unchanged.

## Potential Risks

- Visual balance may need review across desktop and mobile drawer nav.