### PR TITLE
Migrate Airbyte callout icon to lucide

### DIFF
--- a/content/guides/12.integrations/6.airbyte/0.index.md
+++ b/content/guides/12.integrations/6.airbyte/0.index.md
@@ -9,7 +9,7 @@ technologies:
 
 Copy data from your Directus instance into a warehouse or database (BigQuery, Snowflake, Postgres, and more) using the Directus Airbyte source connector.
 
-::callout{icon="heroicons-outline:rocket-launch"}
+::callout{icon="i-lucide-rocket"}
 **Quick Start**
 
 1. **Import the connector**: Add `Airbyte.yaml` as a new source in Airbyte


### PR DESCRIPTION
## Changes

- Replaces the remaining Heroicons Airbyte quick-start callout icon with `i-lucide-rocket`.

## Potential Risks

- Low risk; content-only icon identifier change.

## Review Notes

- Verified the branch diff only touches the Airbyte integration doc.