### PR TITLE
Fix docs Bluesky links

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -331,7 +331,7 @@ export default defineAppConfig({
 		socials: [
 			{
 				icon: 'simple-icons:bluesky',
-				to: 'https://bsky.app/profile/directus.com',
+				to: 'https://bsky.app/profile/directus.io',
 			},
 			{
 				icon: 'simple-icons:x',

--- a/content/getting-started/9.resources.md
+++ b/content/getting-started/9.resources.md
@@ -85,6 +85,6 @@ title: Resources & Links
 **X**: The latest product info and sneak-peeks.
 ::
 
-::callout{icon="i-lucide-link" to="https://bsky.app/profile/directus.com"}
+::callout{icon="i-lucide-link" to="https://bsky.app/profile/directus.io"}
 **Bluesky**: Be part of the conversation with our team.
 ::


### PR DESCRIPTION
## Changes

- Update the docs footer Bluesky URL to the live Directus profile at `directus.io`.
- Update the Getting Started resources Bluesky callout to the same live profile.

## Potential Risks

- Low: static link-only change.

## Review Notes

- Verified `directus.io` resolves via the Bluesky public profile API; `directus.com` returns profile not found.
- Ran `pnpm generate` and a focused Vitest check locally.