### PR TITLE
Fix broken same-page docs anchors

### DIFF
--- a/content/configuration/0.intro.md
+++ b/content/configuration/0.intro.md
@@ -26,9 +26,9 @@ environment variable to instruct Directus to use a local configuration file inst
 file can be one of the following formats:
 
 - [.env](#env)
-- [config.json](#config-json)
-- [config.yaml](#config-yaml)
-- [config.js](#config-js)
+- [config.json](#configjson)
+- [config.yaml](#configyaml)
+- [config.js](#configjs)
 
 ### .env
 

--- a/content/frameworks/02.nuxt/11.reusable-blocks.md
+++ b/content/frameworks/02.nuxt/11.reusable-blocks.md
@@ -375,7 +375,7 @@ Now we are ready to test the application. In Directus create a page and add some
 
 ![Directus page with multiple blocks added](/img/PageContentExample.png)
 
-In the example above the slug used is `becoming-a-productive-rabbit` so we can use that to visit our page at [http://your-wesite-url/becoming-a-productive-rabbit](#). 
+In the example above the slug used is `becoming-a-productive-rabbit` so we can use that to visit our page at `http://your-website-url/becoming-a-productive-rabbit`.
 
 ![Nuxt application page showing the page content blocks](/img/FinalContent.png)
 

--- a/content/tutorials/5.extensions/validating-third-party-jwts-in-directus.md
+++ b/content/tutorials/5.extensions/validating-third-party-jwts-in-directus.md
@@ -225,11 +225,11 @@ With the JWT payload verified we can map its claims to a Directus accountability
 
 This mapping can be done in several ways. The three most common:
 
-- [Dynamically via Claim](#dynamically-via-claim)
-- [Static Mapping](#static-mapping)
-- [Auto-Provisioning](#auto-provisioning)
+- [Lookup User Dynamically Using a Claim](#option-1---lookup-user-dynamically-using-a-claim)
+- [Use a Static Mapping](#option-2--use-a-static-mapping)
+- [Auto-Provision Users](#option-3---auto-provision-users)
 
-#### Dynamically via Claim
+#### Option 1 - Lookup User Dynamically Using a Claim
 
 We match a Directus user's `external_identifier` against the JWT's `sub` claim, then use their information to build the accountability.
 
@@ -293,7 +293,7 @@ export default defineHook(({ filter }, { logger, services }) => {
 
 This approach is flexible and works well with automated provisioning.
 
-#### Static Mapping
+#### Option 2- Use a Static Mapping
 
 If the mapping between the claim and user id/role is known ahead of time, you can avoid DB queries entirely.
 
@@ -361,7 +361,7 @@ export default defineHook(({ filter }, { logger, services }) => {
 
 This method is best for small systems or service accounts.
 
-#### Auto-Provisioning
+#### Option 3 - Auto-Provision Users
 
 This method combines user lookup with auto-provisioning for dynamic service account management.
 
@@ -473,7 +473,7 @@ This guide covers the basics. For a production-ready setup, you may want to:
 
 ## Full Example
 
-The snippet below combines every step into a single, copy-ready `index.ts` using the [Dynamically via Claim](#dynamically-via-claim) mapping strategy. Replace `<your-okta-domain>` with your own domain, and swap the mapping section for [Static Mapping](#static-mapping) or [Auto-Provisioning](#auto-provisioning) if they fit your use case better.
+The snippet below combines every step into a single, copy-ready `index.ts` using the [Lookup User Dynamically Using a Claim](#option-1---lookup-user-dynamically-using-a-claim) mapping strategy. Replace `<your-okta-domain>` with your own domain, and swap the mapping section for [Use a Static Mapping](#option-2--use-a-static-mapping) or [Auto-Provision Users](#option-3---auto-provision-users) if they fit your use case better.
 
 ```ts
 import {


### PR DESCRIPTION
## Changes

- Align configuration file links with rendered heading IDs.
- Rename JWT mapping headings/links so the reported option fragments resolve.
- Replace the Nuxt reusable-blocks placeholder `#` link with a code-formatted sample URL.

## Potential Risks

- JWT option heading text changes slightly to preserve requested fragment IDs.

## Review Notes

- Verified with `pnpm build`.