### PR TITLE
Improve release notes navigation and search

### DIFF
--- a/app/composables/useSectionNavigation.ts
+++ b/app/composables/useSectionNavigation.ts
@@ -58,15 +58,23 @@ export function useSectionNavigation(options: { immediate?: boolean } = {}) {
 		children: item.children?.map(collapseDescendants),
 	});
 
-	const sectionNavigation = computed<ContentNavigationItem[]>(() => {
-		const section = currentSection.value;
-		if (!section) return [];
-
-		const topLevel = section.id === 'deploy' || section.id === 'community'
+	const getSectionTopLevel = (section: DocsSection) => {
+		const topLevel = section.id === 'deploy'
 			? section.prefixes
 				.map(findRoot)
 				.filter((item): item is ContentNavigationItem => item !== null)
 			: findRoot(section.prefixes[0]!)?.children ?? [];
+
+		return section.id === 'releases'
+			? topLevel.filter(item => item.path !== section.to)
+			: topLevel;
+	};
+
+	const sectionNavigation = computed<ContentNavigationItem[]>(() => {
+		const section = currentSection.value;
+		if (!section) return [];
+
+		const topLevel = getSectionTopLevel(section);
 
 		return topLevel.map(item => ({
 			...item,
@@ -95,9 +103,7 @@ export function useSectionNavigation(options: { immediate?: boolean } = {}) {
 	const mobileNavigationTree = computed<ContentNavigationItem[]>(() => {
 		if (currentGroup.value?.id === 'docs') {
 			return groupSections.value.flatMap((section) => {
-				const topLevel = section.id === 'deploy' || section.id === 'community'
-					? section.prefixes.map(findRoot).filter((item): item is ContentNavigationItem => item !== null)
-					: findRoot(section.prefixes[0]!)?.children ?? [];
+				const topLevel = getSectionTopLevel(section);
 				const items = topLevel.map(item => ({
 					...item,
 					children: item.children?.map(collapseDescendants),

--- a/content/releases/2.changelog.md
+++ b/content/releases/2.changelog.md
@@ -1,5 +1,6 @@
 ---
 stableId: b28e12b3-a906-4907-b5e5-2f9c25a92d08
+title: Changelog
 description: A monthly summary of what's new from the Directus team.
 ---
 

--- a/scripts/index-docs-chunker.ts
+++ b/scripts/index-docs-chunker.ts
@@ -584,7 +584,6 @@ export function collectMarkdownDocuments() {
 	const partials = loadPartials();
 	const files = listRoutableContentFiles('content').filter(file => {
 		if (file.startsWith('content/_partials/')) return false;
-		if (file.startsWith('content/releases/')) return false;
 		return true;
 	});
 

--- a/shared/utils/docsSections.ts
+++ b/shared/utils/docsSections.ts
@@ -8,6 +8,7 @@ export type DocsSectionId
 		| 'reference'
 		| 'api'
 		| 'community'
+		| 'releases'
 		| 'licensing';
 
 export type DocsGroupId = 'docs' | 'reference' | 'legacy-reference' | 'examples' | 'licensing';
@@ -89,8 +90,15 @@ export const docsSections: DocsSection[] = [
 		id: 'community',
 		label: 'Community',
 		to: '/community/overview/welcome',
-		prefixes: ['/community', '/releases'],
+		prefixes: ['/community'],
 		icon: 'i-lucide-users',
+	},
+	{
+		id: 'releases',
+		label: 'Releases',
+		to: '/releases',
+		prefixes: ['/releases'],
+		icon: 'i-lucide-tag',
 	},
 	{
 		id: 'licensing',
@@ -107,7 +115,7 @@ export const docsGroups: DocsGroup[] = [
 		label: 'Docs',
 		to: '/getting-started/overview',
 		icon: 'i-lucide-book-open',
-		sectionIds: ['getting-started', 'guides', 'deploy', 'configuration', 'frameworks', 'community'],
+		sectionIds: ['getting-started', 'guides', 'deploy', 'configuration', 'frameworks', 'community', 'releases'],
 	},
 	{
 		id: 'reference',


### PR DESCRIPTION
## Changes

- Adds Releases as its own docs section instead of grouping release pages under Community.
- Includes release docs in the Typesense indexing pass so release notes and breaking changes can appear in docs search.

## Potential Risks

- Live search results will not change until the search index is rebuilt.

## Review Notes

- Verified with `pnpm typecheck:scripts` and `pnpm test:search`.