### PR TITLE
Fix broken markup in interfaces guide

### DIFF
--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -296,45 +296,65 @@ Nested tree of checkboxes that can be expanded or collapsed.
 
 ::callout{icon="i-lucide-info"}
 **Understanding Value Combining Options**
+
 In a Checkboxes (Tree) interface, checkboxes can exist within a parent checkbox. Value combining determines the final value when selecting items in a tree.
 
-- `All` returns all checked values.
-  :::collapsible{name="examples" class="mt-2"}
-  | Selection | Final Value |
-  | ------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-  | :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]` |
-  | :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2` | `[child1, child2, parent]` |
-  :::
-- `Branch` returns the top-most values that are selected.
-  :::collapsible{name="examples" class="mt-2"}
-  | Selection | Final Value |
-  | ------------------------------------------------------------------------------------------------------------------------ | ----------- |
-  | :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]` |
-  | :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2` | `[parent]` |
-  :::
-- `Leaf` returns the deepest values that are selected
-  :::collapsible{name="examples" class="mt-2"}
-  | Selection | Final Value |
-  | ------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-  | :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]` |
-  | :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2` | `[child1, child2]` |
-  :::
-- `Indeterminate` returns checked items, and always returns a parent when one or more children are selected.
-  :::collapsible{name="examples" class="mt-2"}
-  | Selection | Final Value |
-  | ------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-  | :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1, parent]` |
-  | :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2` | `[child1, child2, parent]` |
-  :::
-- `Exclusive` returns either the parent or child elements, but not both.
-  :::collapsible{name="examples" class="mt-2"}
-  | Selection | Final Value |
-  | ------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-  | :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[parent]` |
-  | :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]` |
-  | :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2` | `[child1, child2]` |
-  :::
-  ::
+**`All`** returns all checked values.
+
+:::collapsible{name="examples" class="mt-2"}
+
+| Selection                                                                                                                                                                                 | Final Value                |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]`                 |
+| :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2`                 | `[child1, child2, parent]` |
+
+:::
+
+**`Branch`** returns the top-most values that are selected.
+
+:::collapsible{name="examples" class="mt-2"}
+
+| Selection                                                                                                                                                                                 | Final Value |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]`  |
+| :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2`                 | `[parent]`  |
+
+:::
+
+**`Leaf`** returns the deepest values that are selected.
+
+:::collapsible{name="examples" class="mt-2"}
+
+| Selection                                                                                                                                                                                 | Final Value        |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]`         |
+| :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2`                 | `[child1, child2]` |
+
+:::
+
+**`Indeterminate`** returns checked items, and always returns a parent when one or more children are selected.
+
+:::collapsible{name="examples" class="mt-2"}
+
+| Selection                                                                                                                                                                                 | Final Value                |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1, parent]`         |
+| :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2`                 | `[child1, child2, parent]` |
+
+:::
+
+**`Exclusive`** returns either the parent or child elements, but not both.
+
+:::collapsible{name="examples" class="mt-2"}
+
+| Selection                                                                                                                                                                                 | Final Value        |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| :icon{name="material-symbols:check-box"} `parent`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[parent]`         |
+| :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box-outline"} `child2` | `[child1]`         |
+| :icon{name="material-symbols:check-box-outline"} `parent`<br>&emsp; :icon{name="material-symbols:check-box"} `child1`<br>&emsp; :icon{name="material-symbols:check-box"} `child2`         | `[child1, child2]` |
+
+:::
+::
 
 ### Radio Buttons
 


### PR DESCRIPTION
This fixes the markup being broken in the inteface section after checkbox tree - https://directus.com/docs/guides/data-model/interfaces#checkboxes-tree. It does not fix the examples not being togglabe as that appears to be a seperate issue.

<img width="1512" height="921" alt="Screenshot 2026-06-15 at 12 00 42 PM" src="https://github.com/user-attachments/assets/43643710-9a03-4c05-8585-aaa7b50e8d64" />
