### PR TITLE
Document network requirements for licensing

### DIFF
--- a/content/licensing/1.overview.md
+++ b/content/licensing/1.overview.md
@@ -82,7 +82,7 @@ See the [General configuration](/configuration/general#license) reference for th
 
 ## Network Requirements
 
-In online mode, Directus makes outbound HTTPS requests to `https://licensing.directus.com`. We recommend If your network restricts outbound traffic, allow the following endpoints:
+In online mode, Directus makes outbound HTTPS requests to `https://licensing.directus.com`. If your network restricts outbound traffic, we recommend allowing the following endpoints:
 
 | Method | Endpoint | Purpose |
 | --- | --- | --- |

--- a/content/licensing/1.overview.md
+++ b/content/licensing/1.overview.md
@@ -82,7 +82,7 @@ See the [General configuration](/configuration/general#license) reference for th
 
 ## Network Requirements
 
-In online mode, Directus makes outbound HTTPS requests to `https://licensing.directus.com`. If your network restricts outbound traffic, allow the following endpoints:
+In online mode, Directus makes outbound HTTPS requests to `https://licensing.directus.com`. We recommend If your network restricts outbound traffic, allow the following endpoints:
 
 | Method | Endpoint | Purpose |
 | --- | --- | --- |
@@ -96,6 +96,8 @@ In online mode, Directus makes outbound HTTPS requests to `https://licensing.dir
 | `GET` | `/api/licenses/addons/options` | Fetching available addon options |
 | `PATCH` | `/api/licenses/addons` | Purchasing or modifying addons |
 | `DELETE` | `/api/licenses/addons` | Removing addons |
+
+**Notice**: These endpoints are subject to future change and the list may be modified or be extended in the future.
 
 If outbound access to `https://licensing.directus.com` is not possible, use an [offline license token](#offline-mode) instead. Offline tokens are validated locally and require no outbound network access. Offline mode is only available on Enterprise plans.
 

--- a/content/licensing/1.overview.md
+++ b/content/licensing/1.overview.md
@@ -80,6 +80,26 @@ If no license is configured, the instance runs on the core tier.
 
 See the [General configuration](/configuration/general#license) reference for the full `LICENSE_KEY` and `LICENSE_TOKEN` environment variable details.
 
+## Network Requirements
+
+In online mode, Directus makes outbound HTTPS requests to `https://licensing.directus.com`. If your network restricts outbound traffic, allow the following endpoints:
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/.well-known/jwks.json` | Token signature verification |
+| `POST` | `/api/licenses/preview` | License preview before activation |
+| `POST` | `/api/licenses/activate` | Initial license activation |
+| `POST` | `/api/licenses/refresh` | Periodic license revalidation |
+| `POST` | `/api/licenses/update` | Plan or addon changes |
+| `POST` | `/api/licenses/deactivate` | License deactivation |
+| `POST` | `/api/licenses/portal` | Opening the Stripe billing portal |
+| `GET` | `/api/licenses/addons/options` | Fetching available addon options |
+| `PATCH` | `/api/licenses/addons` | Purchasing or modifying addons |
+| `DELETE` | `/api/licenses/addons` | Removing addons |
+
+If outbound access to `https://licensing.directus.com` is not possible, use an [offline license token](#offline-mode) instead. Offline tokens are validated locally and require no outbound network access. Offline mode is only available on Enterprise plans.
+
+
 ## License Statuses
 
 | Status | Meaning |


### PR DESCRIPTION
Added network requirements for licensing and endpoints:

## Network Requirements

In online mode, Directus makes outbound HTTPS requests to `https://licensing.directus.com`. If your network restricts outbound traffic, allow the following endpoints:

| Method | Endpoint | Purpose |
| --- | --- | --- |
| `GET` | `/.well-known/jwks.json` | Token signature verification |
| `POST` | `/api/licenses/preview` | License preview before activation |
| `POST` | `/api/licenses/activate` | Initial license activation |
| `POST` | `/api/licenses/refresh` | Periodic license revalidation |
| `POST` | `/api/licenses/update` | Plan or addon changes |
| `POST` | `/api/licenses/deactivate` | License deactivation |
| `POST` | `/api/licenses/portal` | Opening the Stripe billing portal |
| `GET` | `/api/licenses/addons/options` | Fetching available addon options |
| `PATCH` | `/api/licenses/addons` | Purchasing or modifying addons |
| `DELETE` | `/api/licenses/addons` | Removing addons |

If outbound access to `https://licensing.directus.com` is not possible, use an [offline license token](#offline-mode) instead. Offline tokens are validated locally and require no outbound network access. Offline mode is only available on Enterprise plans.
