### PR TITLE
Document IMPORT_MAX_FILE_SIZE environment variable

### DIFF
--- a/content/configuration/security-limits.md
+++ b/content/configuration/security-limits.md
@@ -186,5 +186,6 @@ Allows you to configure hard technical limits, to prevent abuse and optimize for
 | `QUERYSTRING_MAX_PARSE_DEPTH` | The maximum object depth when parsing URL query parameters using the querystring format                                            | `10`          |
 | `QUERYSTRING_ARRAY_LIMIT`     | The array limit when parsing URL query parameters using the querystring format                                                     | `500`         |
 | `MAX_IMPORT_ERRORS`           | The maximum number of validation errors permitted while importing records before the process is cancelled and the errors returned. | `1000`        |
+| `IMPORT_MAX_FILE_SIZE`        | The maximum size of a file uploaded to the import endpoint. Accepts number of bytes, or human readable string; no limit by default. Returns `413` when exceeded. |               |
 
 <sup>[1]</sup> Defaults to `auth_login`, `auth_refresh`, `auth_password_request`, `auth_password_reset`, `users_register`, `users_register_verify`, `users_invite_accept`, `users_me_tfa_generate`, `users_me_tfa_enable`, `users_me_tfa_disable`, and `utils_cache_clear`. Setting your own list overrides these.


### PR DESCRIPTION
## What

Documents the new `IMPORT_MAX_FILE_SIZE` environment variable in the Limits & Optimizations table on the Security & Limits configuration page.

It caps the size of a file uploaded to the import endpoint (`POST /utils/import/:collection`), returning `413 Content Too Large` when exceeded. Unset (no limit) by default, and separate from `FILES_MAX_UPLOAD_SIZE`.

## Why

The variable is introduced in the code PR below. Background imports are now spooled to disk before processing, so without a cap an unbounded upload could fill the disk. This documents the new knob operators can use to bound it.

## References

- Code PR: directus/directus#27862
- Linear: [CMS-2802](https://linear.app/directus/issue/CMS-2802)