### PR TITLE
Document WYSIWYG TinyMCE to Tiptap migration

### DIFF
--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -17,13 +17,15 @@ You can navigate through Directus Studio entirely with your keyboard. The Skip M
 - Apply edits in modals/drawers/popovers with `meta` + `enter`.
 - Cancel/exit modals/drawers/popovers with the `escape` key.
 
-Special shortcuts for the TinyMCE/WYSIWYG Editor:
+Special shortcuts for the WYSIWYG editor:
 
-- `alt` + `F10` Focus/jump to toolbar
-- Arrow Keys: Navigate left/right through toolbar
-- `Esc`: Return to the editor content area
+- Use `Tab` to move focus into and through the toolbar, and arrow keys to move between adjacent tools.
+- Press `Esc` to return focus to the editor content area.
+- Standard formatting shortcuts apply in the content area, for example `meta` + `b` (bold), `meta` + `i` (italic), and `meta` + `k` (insert link).
 
-Read more: https://www.tiny.cloud/docs/tinymce/6/tinymce-and-screenreaders/
+<!-- TODO(CMS-2851): confirm the exact toolbar keyboard-navigation keys for the Tiptap-based editor before publishing. -->
+
+The WYSIWYG editor was rebuilt on [Tiptap](https://tiptap.dev) in Directus 12. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap) for details.
 
 ### Things to keep in mind
 

--- a/content/getting-started/10.accessibility.md
+++ b/content/getting-started/10.accessibility.md
@@ -23,9 +23,9 @@ Special shortcuts for the WYSIWYG editor:
 - Press `Esc` to return focus to the editor content area.
 - Standard formatting shortcuts apply in the content area, for example `meta` + `b` (bold), `meta` + `i` (italic), and `meta` + `k` (insert link).
 
-<!-- TODO(CMS-2851): confirm the exact toolbar keyboard-navigation keys for the Tiptap-based editor before publishing. -->
+<!-- TODO(CMS-2851): confirm the exact toolbar keyboard-navigation keys and the release version for the Tiptap-based editor before publishing. -->
 
-The WYSIWYG editor was rebuilt on [Tiptap](https://tiptap.dev) in Directus 12. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap) for details.
+The WYSIWYG editor was rebuilt on [Tiptap](https://tiptap.dev) in Directus 12.2.0. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap) for details.
 
 ### Things to keep in mind
 

--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -87,17 +87,21 @@ Textarea input for longer plain text.
 
 ![A What You See Is What You Get (WYSIWYG) form input that has a toolbar for formatting](/img/262f71a7-8cc8-4402-85b9-b80dbc2a60ba.webp)
 
-The What You See Is What You Get (WYSIWYG) editor provides a text area with rich formatting options in the toolbar.
+The What You See Is What You Get (WYSIWYG) editor provides a text area with rich formatting options in the toolbar. Content is stored as HTML.
 
-| Configuration       | Options                                                                                                                                                                               |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Types               | `Text`                                                                                                                                                                                |
-| Toolbar             | Allows for customization of visible formatting options                                                                                                                                |
-| Folder              | Default folder to store uploaded files. Does not affect existing files.                                                                                                               |
-| Soft Limit          | Used to limit the number of characters within the Data Studio.                                                                                                                        |
-| Static Access Token | Token appended to asset URLs when displaying in the editor.                                                                                                                           |
-| Custom Formats      | JSON array of formatting that is passed to the `style_formats` config option of the WYSIWYG editor instance. [TinyMCE Documentation](https://www.tiny.cloud/docs/demo/format-custom/) |
-| Options Override    | JSON object to override the default config option of the WYSIWYG editor instance. [TinyMCE Documentation](https://www.tiny.cloud/docs/configure/)                                     |
+| Configuration       | Options                                                                        |
+| ------------------- | ------------------------------------------------------------------------------ |
+| Types               | `Text`                                                                         |
+| Toolbar             | Allows for customization of visible formatting options.                        |
+| Folder              | Default folder to store uploaded files. Does not affect existing files.        |
+| Soft Limit          | Used to limit the number of characters within the Data Studio.                 |
+| Static Access Token | Token appended to asset URLs when displaying in the editor.                    |
+| Custom Formats      | JSON array of custom formatting styles to add to the editor's formatting menu. |
+| Options Override    | Deprecated and no longer applied. See the note below.                          |
+
+::callout{icon="i-lucide-info"}
+**The editor's engine changed in Directus 12.** The WYSIWYG interface is now built on [Tiptap](https://tiptap.dev). Existing fields keep working without migration, but stored HTML is normalized to the editor's supported markup on first edit, and the **Options Override** (`tinymceOverrides`) option is deprecated. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap) for details.
+::
 
 ### Markdown
 

--- a/content/guides/01.data-model/3.interfaces.md
+++ b/content/guides/01.data-model/3.interfaces.md
@@ -96,7 +96,7 @@ The What You See Is What You Get (WYSIWYG) editor provides a text area with rich
 | Folder              | Default folder to store uploaded files. Does not affect existing files.        |
 | Soft Limit          | Used to limit the number of characters within the Data Studio.                 |
 | Static Access Token | Token appended to asset URLs when displaying in the editor.                    |
-| Custom Formats      | JSON array of custom formatting styles to add to the editor's formatting menu. |
+| Custom Formats      | JSON array of custom formatting styles to add to the editor's formatting menu. Only inline formats are supported; block, selector, and wrapper formats are ignored. |
 | Options Override    | Deprecated and no longer applied. See the note below.                          |
 
 ::callout{icon="i-lucide-info"}

--- a/content/releases/2.changelog.md
+++ b/content/releases/2.changelog.md
@@ -10,6 +10,13 @@ Each month, some of the Directus team talk through what’s new including core r
 
 [Watch The Changelog on Directus TV.](https://directus.com/tv/the-changelog)
 
+## July 2026
+
+<!-- TODO(CMS-2851): confirm the release version/date before publishing. -->
+
+- Directus 12.2.0 has a potential breaking change: the WYSIWYG (rich text) interface is now built on [Tiptap](https://tiptap.dev) instead of TinyMCE. Existing fields keep working, but stored HTML is normalized to supported markup on first edit and the **Options Override** (`tinymceOverrides`) option is deprecated. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap).
+- Rebuilt the WYSIWYG editor on Tiptap, an actively maintained and license-compatible library, with a redesigned toolbar that collapses overflowing tools into a Show More menu.
+
 ## March 2026
 
 - [Directus 11.16.0](https://github.com/directus/directus/releases/tag/v11.16.0) has some potential breaking changes: existing `draft`-keyed versions have their display name standardized to "Draft"; `@directus/visual-editing` must be updated to v2.0.0; `requestPasswordReset` now returns `Forbidden` for external auth users.

--- a/content/releases/2.changelog.md
+++ b/content/releases/2.changelog.md
@@ -14,7 +14,7 @@ Each month, some of the Directus team talk through what’s new including core r
 
 <!-- TODO(CMS-2851): confirm the release version/date before publishing. -->
 
-- Directus 12.2.0 has a potential breaking change: the WYSIWYG (rich text) interface is now built on [Tiptap](https://tiptap.dev) instead of TinyMCE. Existing fields keep working, but stored HTML is normalized to supported markup on first edit and the **Options Override** (`tinymceOverrides`) option is deprecated. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap).
+- Directus 12.2.0 has a breaking change: the WYSIWYG (rich text) interface is now built on [Tiptap](https://tiptap.dev) instead of TinyMCE. Existing fields keep working, but stored HTML is normalized to supported markup on first edit and the **Options Override** (`tinymceOverrides`) option is deprecated. See the [Version 12 breaking changes](/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap).
 - Rebuilt the WYSIWYG editor on Tiptap, an actively maintained and license-compatible library, with a redesigned toolbar that collapses overflowing tools into a Show More menu.
 
 ## March 2026

--- a/content/releases/3.breaking-changes/3.version-12.md
+++ b/content/releases/3.breaking-changes/3.version-12.md
@@ -4,6 +4,36 @@ title: Version 12
 description: Breaking changes may require action on your part before upgrading.
 ---
 
+## Version 12.2.0
+
+<!-- TODO(CMS-2851): confirm the release version this ships in before publishing. -->
+
+### WYSIWYG editor rebuilt on Tiptap
+
+The WYSIWYG interface (`input-rich-text-html`) has replaced its TinyMCE editor with [Tiptap](https://tiptap.dev). The interface id, option keys, and HTML storage format are unchanged, so existing fields continue to work without migration. Two changes may require action.
+
+#### Content is normalized on first edit
+
+The editor's schema now defines which HTML it can represent. When you open an existing value, change it, and save, markup the schema does not support is normalized or removed. This only happens when a field is edited and saved. Values you do not touch are left as they are.
+
+Most common HTML is preserved, including:
+
+- Semantic tags such as `<section>`, `<article>`, `<figure>`/`<figcaption>`, `<details>`/`<summary>`, `<dl>`/`<dt>`/`<dd>`, `<mark>`, and `<abbr>`.
+- `class`, `id`, `data-*`, and `aria-*` attributes on supported elements.
+
+The following are changed or dropped on save:
+
+- HTML comments.
+- Inline `style` values outside the editor's supported set.
+- `<script>` and `<style>` tags.
+- Custom or unrecognized tags not listed above.
+
+The editor shows a warning the first time you edit a field whose stored HTML would be normalized. You can dismiss this warning permanently. If you style or process stored HTML by tag, class, or attribute, review affected fields before saving.
+
+#### `Options Override` (`tinymceOverrides`) is deprecated
+
+This option passed raw TinyMCE configuration to the editor and no longer has any effect. Existing values are ignored and log a deprecation warning in the browser console, and the option is hidden for new fields. It will be removed in a future release. Configure the toolbar, custom formats, font families, and font sizes through the interface's dedicated options instead.
+
 ## Version 12.1.0
 
 ### Removal of /hash endpoints

--- a/content/releases/3.breaking-changes/3.version-12.md
+++ b/content/releases/3.breaking-changes/3.version-12.md
@@ -16,19 +16,27 @@ The WYSIWYG interface (`input-rich-text-html`) has replaced its TinyMCE editor w
 
 The editor's schema now defines which HTML it can represent. When you open an existing value, change it, and save, markup the schema does not support is normalized or removed. This only happens when a field is edited and saved. Values you do not touch are left as they are.
 
-Most common HTML is preserved, including:
+The editor supports the following HTML:
 
-- Semantic tags such as `<section>`, `<article>`, `<figure>`/`<figcaption>`, `<details>`/`<summary>`, `<dl>`/`<dt>`/`<dd>`, `<mark>`, and `<abbr>`.
-- `class`, `id`, `data-*`, and `aria-*` attributes on supported elements.
+- Text blocks and marks: `<p>`, `<h1>`-`<h6>`, `<ul>`, `<ol>`, `<li>`, `<blockquote>`, `<pre>`, `<code>`, `<a>`, `<strong>`/`<b>`, `<em>`/`<i>`, `<u>`, `<s>`/`<del>`, `<sub>`, `<sup>`, `<span>`, `<br>`, and `<hr>`.
+- Media and tables: `<img>`, `<video>`, `<audio>`, `<iframe>`, and `<table>` with its row and cell tags.
+- Semantic tags: `<section>`, `<article>`, `<figure>`/`<figcaption>`, `<details>`/`<summary>`, `<dl>`/`<dt>`/`<dd>`, `<mark>`, and `<abbr>`.
+- `class`, `id`, `title`, `role`, `lang`, `dir`, `data-*`, and `aria-*` attributes on supported elements.
 
 The following are changed or dropped on save:
 
 - HTML comments.
 - Inline `style` values outside the editor's supported set.
 - `<script>` and `<style>` tags.
-- Custom or unrecognized tags not listed above.
+- Tags not listed above, including `<div>` wrappers. Their content is kept where possible, but the tags themselves are removed.
 
-The editor shows a warning the first time you edit a field whose stored HTML would be normalized. You can dismiss this warning permanently. If you style or process stored HTML by tag, class, or attribute, review affected fields before saving.
+When a field's stored HTML contains markup that would be normalized, the editor loads read-only and shows a notice. Selecting the field opens a dialog with a diff of what would change, and three choices:
+
+- **Keep Read-only** leaves the value untouched.
+- **Edit Anyway** unlocks the editor. Unsupported markup is removed when you save.
+- **Edit Raw HTML** switches the field to a raw HTML editor, so you can edit the value without any normalization.
+
+If you style or process stored HTML by tag, class, or attribute, review affected fields before saving.
 
 #### `Options Override` (`tinymceOverrides`) is deprecated
 


### PR DESCRIPTION
## What

Documents the WYSIWYG (`input-rich-text-html`) editor engine swap from **TinyMCE 6 → Tiptap 3** ([Replace TinyMCE (WYSIWYG)](https://linear.app/directus/project/replace-tinymce-wysiwyg-6e6388729457), CMS-2851).

## Changes

- **Releases** — new Version 12 breaking-change notice ("WYSIWYG editor rebuilt on Tiptap") covering first-edit HTML normalization and the `tinymceOverrides` deprecation, plus a matching changelog entry.
- **Interface reference** (`guides/data-model/interfaces`) — reworded the WYSIWYG config table, dropped the TinyMCE `style_formats`/config doc links, marked **Options Override** deprecated, and linked to the breaking changes.
- **Accessibility** — removed TinyMCE-specific `alt`+`F10` shortcuts and the dead `tiny.cloud` link; replaced with editor/formatting shortcuts.

## Scope

Only the entries carrying TinyMCE-specific detail were touched. The ~24 generic "WYSIWYG field" references across framework guides and tutorials were left as-is because the interface id and stored-HTML contract are preserved.

Note: CMS-2839 and CMS-2840 shipped, so semantic tags and `class`/`id`/`data-*`/`aria-*` attributes are **preserved**. The docs reflect the narrower residual scope (HTML comments, non-whitelisted inline styles, `<script>`/`<style>`, unrecognized tags).

## Before merging

Two `TODO(CMS-2851)` flags are intentionally left inline for a maintainer to confirm:
1. **Release version** — `12.2.0` is a placeholder (CMS-2650 still in progress).
2. **Toolbar keyboard-navigation keys** — the exact Tiptap toolbar focus keys need verifying against the shipped build.

Fixes CMS-2851