### PR TITLE
docs: warn that empty TZ breaks scheduled cron jobs

### DIFF
--- a/content/configuration/1.general.md
+++ b/content/configuration/1.general.md
@@ -63,6 +63,17 @@ The following commands set details for the first admin user created when the pro
 | `ADMIN_TOKEN`    | The API token of the first user that's automatically created during bootstrapping.     |               |
 
 
+## Timezone
+
+Scheduled jobs in Directus (for example telemetry, metrics, retention cleanup, and upload cleanup) use the standard `TZ` environment variable.
+
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+**Warning**  
+Do not set `TZ` to an empty string. Use a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `UTC` or `Europe/Berlin`, or omit `TZ` entirely so the host default applies.
+
+An empty value (for example `TZ=` in Docker) can prevent Directus from starting with errors such as `CronError: ERROR: You specified an invalid date.`
+::
+
 ## Telemetry
 
 To more accurately gauge the frequency of installation, version fragmentation, and general size of the user base, Directus collects usage data about your environment.


### PR DESCRIPTION
## Summary

Closes #512.

Documents that an empty `TZ` environment variable breaks Directus scheduled cron jobs (telemetry, metrics, retention, upload cleanup, etc.) after the switch to the `cron` package in v11.13+, and that a valid IANA timezone or an unset `TZ` is required.