### PR TITLE
docs: clarify getting started Docker Compose is not production-ready

### DIFF
--- a/content/getting-started/2.create-a-project.md
+++ b/content/getting-started/2.create-a-project.md
@@ -103,7 +103,10 @@ docker compose up
 
 Directus should now be available at http://localhost:8055 or http://127.0.0.1:8055, where you'll see an onboarding screen to configure your first Admin account.
 
-The project that runs from this `docker-compose.yml` file is not production-ready but enough to use many features.
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+**Not for production**  
+This Docker Compose example uses SQLite and is intended for local exploration only. For a production-oriented setup with Postgres, Redis, and related services, see the [Docker Compose examples](/self-hosting/deploying#docker-compose-examples) in Deploying Directus.
+::
 
 ## Deploy Directus
 


### PR DESCRIPTION
## Summary

Closes #475.

Replaces the brief note under the getting-started Docker Compose example with a warning callout clarifying that the SQLite setup is for local exploration only, and links to the production-oriented Docker Compose examples in Deploying Directus.