### PR TITLE
Remove Marketplace beta references

### DIFF
--- a/content/community/2.contribution/2.documentation.md
+++ b/content/community/2.contribution/2.documentation.md
@@ -72,7 +72,7 @@ Images are important to illustrate concepts, but they can be difficult to keep c
 To prepare Directus for screenshots, please do the following to your project: 
 
 * Ensure Directus is using the default light theme with the default purple project color.
-* Hide the version number and the beta tag next to Marketplace by adding the following custom CSS: `a.v-list-item.link.version, module-nav-content span.v-chip.x-small.outlined.label.chip { display: none; }`
+* Hide the version number by adding the following custom CSS: `a.v-list-item.link.version { display: none; }`
 * Do not have a user avatar for the current user. Make sure the user's name is 'Admin User'. 
 * When taking screenshots, ensure there is no browser UI unless this is specifically important for the context. 
 * Open your Chrome DevTools, open the device toolbar (emulation).

--- a/content/guides/09.extensions/5.marketplace/0.index.md
+++ b/content/guides/09.extensions/5.marketplace/0.index.md
@@ -1,6 +1,6 @@
 ---
 stableId: 4f45772c-5daf-4e5d-a9ac-c6cf0e1fdb29
-title: Marketplace Beta
+title: Marketplace
 description: The Directus Marketplace provides a way for users to install extensions in their projects directly the Data Studio.
 ---
 
@@ -23,7 +23,7 @@ The currently-installed extensions list is accessible from your project settings
 
 ## Publishing Extensions
 
-The Directus Marketplace uses the Directus Extensions Registry to publish and install extensions. While in beta, all extensions published to npm are available via the registry.
+The Directus Marketplace uses the Directus Extensions Registry to publish and install extensions. All extensions published to npm are available via the registry.
 
 ::callout{icon="i-lucide-book-open" color="primary" to="/guides/extensions/marketplace/publishing"}
 Learn more about publishing extensions to the Directus Marketplace.


### PR DESCRIPTION
## Changes

- Remove the obsolete Marketplace Beta title and beta wording.
- Update screenshot guidance to remove CSS for the retired beta badge.

## Potential Risks

- Documentation-only change; no runtime impact.