### PR TITLE
Document EXTENSIONS_STORAGE_MAX_CONCURRENCY

### DIFF
--- a/content/configuration/extensions.md
+++ b/content/configuration/extensions.md
@@ -10,16 +10,16 @@ description: Configuration for extensions and the Directus Marketplace.
 For guidance on restricting who can install or manage extensions, see [Security Best Practices](/guides/security/best-practices#extensions).
 ::
 
-| Variable                                        | Description                                                                                                                        | Default Value  |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `EXTENSIONS_PATH`<sup>[1]</sup>                 | Path to your local extensions directory, or subdirectory within the configured storage location when `EXTENSIONS_LOCATION` is set. | `./extensions` |
-| `EXTENSIONS_MUST_LOAD`                          | Exit the server when any API extension fails to load.                                                                              | `false`        |
-| `EXTENSIONS_AUTO_RELOAD`<sup>[2], [3]</sup>     | Automatically reload extensions when they have changed.                                                                            | `false`        |
-| `EXTENSIONS_CACHE_TTL`<sup>[4]</sup>            | How long custom app Extensions get cached by browsers.                                                                             |                |
-| `EXTENSIONS_LOCATION`<sup>[5], [6]</sup>        | Key of the configured [storage locations](/configuration/files) to load extensions from a specific storage location.               |                |
-| `EXTENSIONS_LIMIT`                              | Maximum number of extensions you allow to be installed through the Marketplace.                                                    |                |
-| `EXTENSIONS_ROLLDOWN`                           | Enable use of [Rolldown](https://rolldown.rs/) to optimize extensions bundling.                                                    | `false`        |
-| `EXTENSIONS_STORAGE_MAX_CONCURRENCY`<sup>[7]</sup> | Maximum number of concurrent requests when syncing, installing, or uninstalling extensions in the configured storage location.                               | `20`           |
+| Variable                                           | Description                                                                                                                        | Default Value  |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `EXTENSIONS_PATH`<sup>[1]</sup>                    | Path to your local extensions directory, or subdirectory within the configured storage location when `EXTENSIONS_LOCATION` is set. | `./extensions` |
+| `EXTENSIONS_MUST_LOAD`                             | Exit the server when any API extension fails to load.                                                                              | `false`        |
+| `EXTENSIONS_AUTO_RELOAD`<sup>[2], [3]</sup>        | Automatically reload extensions when they have changed.                                                                            | `false`        |
+| `EXTENSIONS_CACHE_TTL`<sup>[4]</sup>               | How long custom app Extensions get cached by browsers.                                                                             |                |
+| `EXTENSIONS_LOCATION`<sup>[5], [6]</sup>           | Key of the configured [storage locations](/configuration/files) to load extensions from a specific storage location.               |                |
+| `EXTENSIONS_LIMIT`                                 | Maximum number of extensions you allow to be installed through the Marketplace.                                                    |                |
+| `EXTENSIONS_ROLLDOWN`                              | Enable use of [Rolldown](https://rolldown.rs/) to optimize extensions bundling.                                                    | `false`        |
+| `EXTENSIONS_STORAGE_MAX_CONCURRENCY`<sup>[7]</sup> | Maximum number of concurrent requests when syncing, installing, or uninstalling extensions in the configured storage location.     | `20`           |
 
 <sup>[1]</sup> When `EXTENSIONS_LOCATION` is set, this defines the path inside the selected storage location where extensions reside.
 

--- a/content/configuration/extensions.md
+++ b/content/configuration/extensions.md
@@ -19,7 +19,7 @@ For guidance on restricting who can install or manage extensions, see [Security 
 | `EXTENSIONS_LOCATION`<sup>[5], [6]</sup>        | Key of the configured [storage locations](/configuration/files) to load extensions from a specific storage location.               |                |
 | `EXTENSIONS_LIMIT`                              | Maximum number of extensions you allow to be installed through the Marketplace.                                                    |                |
 | `EXTENSIONS_ROLLDOWN`                           | Enable use of [Rolldown](https://rolldown.rs/) to optimize extensions bundling.                                                    | `false`        |
-| `EXTENSIONS_SYNC_MAX_CONCURRENCY`<sup>[7]</sup> | Maximum number of concurrent downloads when syncing extensions from the configured storage location.                               | `20`           |
+| `EXTENSIONS_STORAGE_MAX_CONCURRENCY`<sup>[7]</sup> | Maximum number of concurrent requests when syncing, installing, or uninstalling extensions in the configured storage location.                               | `20`           |
 
 <sup>[1]</sup> When `EXTENSIONS_LOCATION` is set, this defines the path inside the selected storage location where extensions reside.
 
@@ -33,7 +33,7 @@ For guidance on restricting who can install or manage extensions, see [Security 
 
 <sup>[6]</sup> The value of `EXTENSIONS_LOCATION` must correspond to a key defined in your `STORAGE_LOCATIONS` environment variable.
 
-<sup>[7]</sup> `EXTENSIONS_SYNC_MAX_CONCURRENCY` only applies when `EXTENSIONS_LOCATION` is set, as extensions are then downloaded from the storage location on startup.
+<sup>[7]</sup> `EXTENSIONS_STORAGE_MAX_CONCURRENCY` only applies when `EXTENSIONS_LOCATION` is set. Invalid values fall back to the default.
 
 ## Marketplace
 

--- a/content/configuration/extensions.md
+++ b/content/configuration/extensions.md
@@ -10,15 +10,16 @@ description: Configuration for extensions and the Directus Marketplace.
 For guidance on restricting who can install or manage extensions, see [Security Best Practices](/guides/security/best-practices#extensions).
 ::
 
-| Variable                                    | Description                                                                                                                        | Default Value  |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `EXTENSIONS_PATH`<sup>[1]</sup>             | Path to your local extensions directory, or subdirectory within the configured storage location when `EXTENSIONS_LOCATION` is set. | `./extensions` |
-| `EXTENSIONS_MUST_LOAD`                      | Exit the server when any API extension fails to load.                                                                              | `false`        |
-| `EXTENSIONS_AUTO_RELOAD`<sup>[2], [3]</sup> | Automatically reload extensions when they have changed.                                                                            | `false`        |
-| `EXTENSIONS_CACHE_TTL`<sup>[4]</sup>        | How long custom app Extensions get cached by browsers.                                                                             |                |
-| `EXTENSIONS_LOCATION`<sup>[5], [6]</sup>    | Key of the configured [storage locations](/configuration/files) to load extensions from a specific storage location.               |                |
-| `EXTENSIONS_LIMIT`                          | Maximum number of extensions you allow to be installed through the Marketplace.                                                    |                |
-| `EXTENSIONS_ROLLDOWN`                       | Enable use of [Rolldown](https://rolldown.rs/) to optimize extensions bundling.                                                    | `false`        |
+| Variable                                        | Description                                                                                                                        | Default Value  |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `EXTENSIONS_PATH`<sup>[1]</sup>                 | Path to your local extensions directory, or subdirectory within the configured storage location when `EXTENSIONS_LOCATION` is set. | `./extensions` |
+| `EXTENSIONS_MUST_LOAD`                          | Exit the server when any API extension fails to load.                                                                              | `false`        |
+| `EXTENSIONS_AUTO_RELOAD`<sup>[2], [3]</sup>     | Automatically reload extensions when they have changed.                                                                            | `false`        |
+| `EXTENSIONS_CACHE_TTL`<sup>[4]</sup>            | How long custom app Extensions get cached by browsers.                                                                             |                |
+| `EXTENSIONS_LOCATION`<sup>[5], [6]</sup>        | Key of the configured [storage locations](/configuration/files) to load extensions from a specific storage location.               |                |
+| `EXTENSIONS_LIMIT`                              | Maximum number of extensions you allow to be installed through the Marketplace.                                                    |                |
+| `EXTENSIONS_ROLLDOWN`                           | Enable use of [Rolldown](https://rolldown.rs/) to optimize extensions bundling.                                                    | `false`        |
+| `EXTENSIONS_SYNC_MAX_CONCURRENCY`<sup>[7]</sup> | Maximum number of concurrent downloads when syncing extensions from the configured storage location.                               | `20`           |
 
 <sup>[1]</sup> When `EXTENSIONS_LOCATION` is set, this defines the path inside the selected storage location where extensions reside.
 
@@ -32,11 +33,13 @@ For guidance on restricting who can install or manage extensions, see [Security 
 
 <sup>[6]</sup> The value of `EXTENSIONS_LOCATION` must correspond to a key defined in your `STORAGE_LOCATIONS` environment variable.
 
+<sup>[7]</sup> `EXTENSIONS_SYNC_MAX_CONCURRENCY` only applies when `EXTENSIONS_LOCATION` is set, as extensions are then downloaded from the storage location on startup.
+
 ## Marketplace
 
-| Variable               | Description                                       | Default Value                  |
-| ---------------------- | ------------------------------------------------- | ------------------------------ |
-| `MARKETPLACE_TRUST`    | One of `sandbox`, `all`                           | `sandbox`                      |
+| Variable               | Description                                       | Default Value                   |
+| ---------------------- | ------------------------------------------------- | ------------------------------- |
+| `MARKETPLACE_TRUST`    | One of `sandbox`, `all`                           | `sandbox`                       |
 | `MARKETPLACE_REGISTRY` | The registry to use for the Directus Marketplace. | `https://registry.directus.com` |
 
 ::callout{icon="i-lucide-info"}


### PR DESCRIPTION
New env var added in directus/directus#27989: extension sync from a configured storage location now downloads files concurrently, bounded by EXTENSIONS_SYNC_MAX_CONCURRENCY (default 20). Adds the variable to the extensions configuration table with a footnote that it only applies when EXTENSIONS_LOCATION is set.

Table columns realigned by the formatter, only the new row and footnote are real changes.