### PR TITLE
Correct local setup info in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,14 @@ Directus documentation site built with Nuxt 3 and `@nuxt/content`. Markdown file
 ## Commands
 
 ```bash
-pnpm install        # Install dependencies (requires Node.js 22, pnpm 9.15.4)
+pnpm install        # Install dependencies (requires Node.js >=22.18, pnpm 10.29.2)
 pnpm dev            # Dev server at http://localhost:3000/docs
 pnpm build          # Production build
 pnpm generate       # Static site generation (used for Vercel deploy)
 pnpm preview        # Preview production build locally
 ```
+
+`pnpm dev` fails with `Invalid URL` unless `DIRECTUS_URL` is set, because the Nuxt server passes it to `createDirectus()` during render. Copy `.env.example` to `.env` before the first run. For content-only work, `DIRECTUS_URL` is the sole required value; the remaining variables emit warnings and disable search, analytics, and the assistant.
 
 There is no test runner configured. Linting is via `@nuxt/eslint` (run through Nuxt's built-in integration).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ pnpm generate       # Static site generation (used for Vercel deploy)
 pnpm preview        # Preview production build locally
 ```
 
-`pnpm dev` fails with `Invalid URL` unless `DIRECTUS_URL` is set, because the Nuxt server passes it to `createDirectus()` during render. Copy `.env.example` to `.env` before the first run. For content-only work, `DIRECTUS_URL` is the sole required value; the remaining variables emit warnings and disable search, analytics, and the assistant.
+`pnpm dev` fails with `Invalid URL` unless `DIRECTUS_URL` is set, because the Nuxt server passes it to `createDirectus()` during render. Copy any missing environment variables from `.env.example` to `.env` before the first run. For content-only work, `DIRECTUS_URL` is the sole required value; the remaining variables emit warnings and disable search, analytics, and the assistant.
 
 There is no test runner configured. Linting is via `@nuxt/eslint` (run through Nuxt's built-in integration).
 


### PR DESCRIPTION
Two things tripped me up setting up locally from a clean checkout.

The stated versions didn't match the manifest. `package.json` asks for Node `>=22.18` and pins pnpm `10.29.2`, but the file said Node 22 and pnpm 9.15.4, so a working setup on Node 24 and pnpm 10 looked wrong.

`pnpm dev` then failed until I set `DIRECTUS_URL`. It surfaces as an `Invalid URL` stack trace from inside the SDK, which doesn't point at the cause, so I added a line about copying `.env.example` first.

Does that match how you set this up, or is there a step I'm missing that makes the `.env` unnecessary? If the change is right, two follow-ups: is CLAUDE.md the right home for that note or does it belong in a README, and should `.env.example` mark `DIRECTUS_URL` as required? Everything in it reads as equally optional today, but only that one seems to block startup.
