### PR TITLE
Improve image dimension restriction docs

### DIFF
--- a/content/configuration/files.md
+++ b/content/configuration/files.md
@@ -159,7 +159,7 @@ the storage driver(s) being used.
 | `ASSETS_CACHE_REVALIDATE`                     | When enabled, sets `Cache-Control: max-age=0, must-revalidate` to force CDNs to revalidate assets on every request.                  | `false`       |
 | `ASSETS_TRANSFORM_MAX_CONCURRENT`             | How many file transformations can be done simultaneously.                                                                            | `25`          |
 | `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION`        | The max pixel dimensions size (width/height) that is allowed to be transformed.                                                      | `6000`        |
-| `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` | The max pixel dimensions size (width/height) that a transformation is allowed to output.                                             | `3000`        |
+| `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` | The max pixel dimensions size (width/height) that a transformation is allowed to output.                                             | `6000`        |
 | `ASSETS_TRANSFORM_TIMEOUT`                    | Max time spent trying to transform an asset.                                                                                         | `7500ms`      |
 | `ASSETS_TRANSFORM_MAX_OPERATIONS`             | The max number of transform operations that is allowed to be processed (excludes saved presets).                                     | `5`           |
 | `ASSETS_INVALID_IMAGE_SENSITIVITY_LEVEL`      | Level of sensitivity to invalid images. See the [`sharp.failOn`](https://sharp.pixelplumbing.com/api-constructor#parameters) option. | `warning`     |
@@ -171,11 +171,20 @@ When enabling `ASSETS_CACHE_REVALIDATE`, CDNs will revalidate assets on every re
 ::
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
+**Transformations and resource usage**
+
 Image transformations can be heavy on memory usage. If you're using a system with 1GB or less available memory, we recommend lowering the allowed concurrent transformations to prevent you from overflowing your server.
 
-`ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` limits the size of the source image, while `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` limits the size of the transformed result. A transformation that projects a width or height larger than the output limit is rejected with an [`ILLEGAL_ASSET_TRANSFORMATION`](/guides/connect/errors) error.
+Two variables bound the pixel dimensions of a transformation:
 
-The output limit applies at every step of a transformation, not only to the final dimensions. A transformation that scales an image up to 10000px and then back down to 2000px is still rejected, because each step is fully applied before the next one runs.
+- `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` limits the source image. A request to transform a larger image is rejected.
+- `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` limits what a transformation is allowed to produce. A transformation projecting a larger width or height is rejected with an [`ILLEGAL_ASSET_TRANSFORMATION`](/guides/connect/errors) error.
+
+The output limit applies at every step of a transformation, not only to the final dimensions. A transformation that scales an image up to 10000px and then back down to 2000px is still rejected, because each step is fully applied before the next one runs. Operations that leave the dimensions unchanged, such as `blur`, are checked too, because they still run against the full image and consume CPU.
+
+A single 6000x6000 result holds up to 144MB in memory before it is encoded, and 25 of those at the default `ASSETS_TRANSFORM_MAX_CONCURRENT` add up to 3.6GB. Lower `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` if you want transformed output bounded more tightly than the images you accept.
+
+See [Transform Files](/guides/files/transform) for the parameters and presets that these limits apply to.
 
 ::
 

--- a/content/guides/05.files/5.transform.md
+++ b/content/guides/05.files/5.transform.md
@@ -8,6 +8,14 @@ description: Learn how to transform files and set custom presets for these trans
 
 Directus allows you to transform assets using URL query parameters. You can pass these as either query parameters to the `assets` endpoint. If a processed asset does not yet exist, it is dynamically generated, stored, and returned.
 
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+**Transformations are bounded by size limits**
+
+`ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` limits the size of the source image, and `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` limits the size a transformation is allowed to produce. A transformation projecting a larger width or height is rejected with an [`ILLEGAL_ASSET_TRANSFORMATION`](/guides/connect/errors) error.
+
+The output limit applies at every step of a transformation, so a chain that scales an image up to 10000px before scaling it back down is rejected even though the final dimensions are within the limit. See [Files configuration](/configuration/files) for these variables and the other transformation limits.
+::
+
 ## Custom Transformations
 
 :video-embed{video-id="59b18d30-080b-42cf-84ef-fdca7542388d"}


### PR DESCRIPTION
## What's Changes

- Updated the documented default for `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION`
- Rewrote asset warning:
   -  Separate source limit from the output limit 
   -  Notes that dimension-neutral operations like `blur` are checked too
   -  Gives real numbers for sizing a server 
- Adds an additional warning to the Transform Files guide with a cross link reference