### PR TITLE
Add missing core collections to Collections Guide

### DIFF
--- a/content/guides/01.data-model/1.collections.md
+++ b/content/guides/01.data-model/1.collections.md
@@ -166,6 +166,10 @@ While fields that come system collection fields cannot be altered, you can exten
 | `directus_folders`             | Provides virtual directories for files.                |
 | `directus_migrations`          | What version of the database you're using.             |
 | `directus_notifications`       | Notifications sent to users.                           |
+| `directus_oauth_clients`       | OAuth clients registered with the MCP server.          |
+| `directus_oauth_codes`         | Authorization codes for MCP OAuth flows.               |
+| `directus_oauth_consents`      | User consent grants for MCP OAuth clients.             |
+| `directus_oauth_tokens`        | Access and refresh tokens for MCP OAuth clients.       |
 | `directus_operations`          | Operations that run in Flows.                          |
 | `directus_panels`              | Individual panels within Insights dashboards.          |
 | `directus_permissions`         | Access permissions attached to policies.               |

--- a/content/guides/01.data-model/1.collections.md
+++ b/content/guides/01.data-model/1.collections.md
@@ -149,34 +149,37 @@ Archived items are hidden in the app by default, but they are still returned nor
 
 While fields that come system collection fields cannot be altered, you can extend system collections.
 
-| Collection               | Purpose                                           |
-| ------------------------ | ------------------------------------------------- |
-| `directus_access`        | Assigns policies to users and roles.              |
-| `directus_activity`      | Accountability logs for all events.               |
-| `directus_collections`   | Additional collection configuration and metadata. |
-| `directus_comments`      | Comments left on items.                           |
-| `directus_dashboards`    | Dashboards within the Insights module.            |
-| `directus_extensions`    | Configuration of extensions.                      |
-| `directus_fields`        | Additional field configuration and metadata.      |
-| `directus_files`         | Metadata for all managed file assets.             |
-| `directus_flows`         | Automation flows.                                 |
-| `directus_folders`       | Provides virtual directories for files.           |
-| `directus_migrations`    | What version of the database you're using.        |
-| `directus_notifications` | Notifications sent to users.                      |
-| `directus_operations`    | Operations that run in Flows.                     |
-| `directus_panels`        | Individual panels within Insights dashboards.     |
-| `directus_permissions`   | Access permissions attached to policies.          |
-| `directus_policies`      | Policies that bundle a set of permissions.        |
-| `directus_presets`       | Presets for collection defaults and bookmarks.    |
-| `directus_relations`     | Relationship configuration and metadata.          |
-| `directus_revisions`     | Data snapshots for all activity.                  |
-| `directus_roles`         | Organizational groups that hold policies.         |
-| `directus_sessions`      | User session information.                         |
-| `directus_settings`      | Project configuration options.                    |
-| `directus_shares`        | Tracks externally shared items.                   |
-| `directus_translations`  | Custom translations.                              |
-| `directus_users`         | System users for the platform.                    |
-| `directus_versions`      | Content Versions for items.                       |
+| Collection                     | Purpose                                                |
+| ------------------------------ | ------------------------------------------------------ |
+| `directus_access`              | Assigns policies to users and roles.                   |
+| `directus_activity`            | Accountability logs for all events.                    |
+| `directus_collections`         | Additional collection configuration and metadata.      |
+| `directus_comments`            | Comments left on items.                                |
+| `directus_dashboards`          | Dashboards within the Insights module.                 |
+| `directus_deployments`         | Connected hosting providers for the Deployment module. |
+| `directus_deployment_projects` | Frontend projects available on a connected provider.   |
+| `directus_deployment_runs`     | Individual build and deploy executions for a project.  |
+| `directus_extensions`          | Configuration of extensions.                           |
+| `directus_fields`              | Additional field configuration and metadata.           |
+| `directus_files`               | Metadata for all managed file assets.                  |
+| `directus_flows`               | Automation flows.                                      |
+| `directus_folders`             | Provides virtual directories for files.                |
+| `directus_migrations`          | What version of the database you're using.             |
+| `directus_notifications`       | Notifications sent to users.                           |
+| `directus_operations`          | Operations that run in Flows.                          |
+| `directus_panels`              | Individual panels within Insights dashboards.          |
+| `directus_permissions`         | Access permissions attached to policies.               |
+| `directus_policies`            | Policies that bundle a set of permissions.             |
+| `directus_presets`             | Presets for collection defaults and bookmarks.         |
+| `directus_relations`           | Relationship configuration and metadata.               |
+| `directus_revisions`           | Data snapshots for all activity.                       |
+| `directus_roles`               | Organizational groups that hold policies.              |
+| `directus_sessions`            | User session information.                              |
+| `directus_settings`            | Project configuration options.                         |
+| `directus_shares`              | Tracks externally shared items.                        |
+| `directus_translations`        | Custom translations.                                   |
+| `directus_users`               | System users for the platform.                         |
+| `directus_versions`            | Content Versions for items.                            |
 
 ## Existing Database Tables
 

--- a/content/guides/01.data-model/1.collections.md
+++ b/content/guides/01.data-model/1.collections.md
@@ -151,8 +151,10 @@ While fields that come system collection fields cannot be altered, you can exten
 
 | Collection               | Purpose                                           |
 | ------------------------ | ------------------------------------------------- |
+| `directus_access`        | Assigns policies to users and roles.              |
 | `directus_activity`      | Accountability logs for all events.               |
 | `directus_collections`   | Additional collection configuration and metadata. |
+| `directus_comments`      | Comments left on items.                           |
 | `directus_dashboards`    | Dashboards within the Insights module.            |
 | `directus_extensions`    | Configuration of extensions.                      |
 | `directus_fields`        | Additional field configuration and metadata.      |
@@ -163,11 +165,12 @@ While fields that come system collection fields cannot be altered, you can exten
 | `directus_notifications` | Notifications sent to users.                      |
 | `directus_operations`    | Operations that run in Flows.                     |
 | `directus_panels`        | Individual panels within Insights dashboards.     |
-| `directus_permissions`   | Access permissions for each role.                 |
+| `directus_permissions`   | Access permissions attached to policies.          |
+| `directus_policies`      | Policies that bundle a set of permissions.        |
 | `directus_presets`       | Presets for collection defaults and bookmarks.    |
 | `directus_relations`     | Relationship configuration and metadata.          |
 | `directus_revisions`     | Data snapshots for all activity.                  |
-| `directus_roles`         | Permission groups for system users.               |
+| `directus_roles`         | Organizational groups that hold policies.         |
 | `directus_sessions`      | User session information.                         |
 | `directus_settings`      | Project configuration options.                    |
 | `directus_shares`        | Tracks externally shared items.                   |


### PR DESCRIPTION
Added missing `directus_*`:
 - `access`
 - `comments`
 - `policies`
 - `deployments`
 - `deployment_projects`
 - `deployment_runs`
 - `oauth_clients`
 - `oauth_codes`
 - `oauth_consents`
 - `oauth_tokens`

Fixed stale `directus_*`:
 - `permissions`
 - `roles`


I used the translations tooltip language where it made sense. I took the liberty to put deployments above the supporting collections even though a true alpha sort would put it last.


- Fixes directus/docs#819 