### PR TITLE
Fix Headings on Relational Data Guide

### DIFF
--- a/content/guides/04.connect/4.relations.md
+++ b/content/guides/04.connect/4.relations.md
@@ -9,11 +9,11 @@ data of a relational field [the `fields` parameter](/guides/connect/query-parame
 queries in GraphQL. This allows you to retrieve the author of your article included in the articles data, or fetch
 related log entry points for your app's analytics data for example.
 
-### Creating / Updating / Deleting
+## Creating / Updating / Deleting
 
 Similarly to fetching, relational content can be modified deeply as well.
 
-#### Many-to-One
+### Many-to-One
 
 Many-to-One relationships are fairly straightforward to manage relationally. You can submit the changes you want
 as an object under the relational key in your collection. For example, if you wanted to create a new featured article on
@@ -49,7 +49,7 @@ nullifying the field:
 }
 ```
 
-#### One-to-Many and Many-to-Many
+### One-to-Many and Many-to-Many
 
 One-to-Many, and therefore Many-to-Many and Many-to-Any, relationships can be updated in one of two ways:
 
@@ -179,7 +179,7 @@ Alternatively, you can provide an object detailing the changes as follows:
 This is useful if you need to have more tightly control on staged changes, or when you're working with a big relational
 dataset.
 
-#### Many-to-Any (Union Types)
+### Many-to-Any (Union Types)
 
 Many-to-Any fields work very similar to a "regular" many-to-many, with the exception that the related field can pull in
 the fields from any of the related collections, for example:


### PR DESCRIPTION
All headings were 1 layer too deep, elevated to appropriate heading (also fixes the on-this-page rendering appropriately)

<img width="509" height="343" alt="Screenshot 2026-09-12 at 20 43 00" src="https://github.com/user-attachments/assets/694a53d9-2523-4946-8052-ed56a09ac963" />
